### PR TITLE
Add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,41 @@
+# Top-most EditorConfig file
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Force LF line endings for all text files (Matches .gitattributes)
+end_of_line = lf
+
+# Windows-specific files require CRLF
+[*.{sln,bat,cmd,ps1}]
+end_of_line = crlf
+
+# XML-ish files typically use 2-space indent
+[*.{csproj,props,targets,config,manifest,resx,xml,yml,yaml,json}]
+indent_size = 2
+
+# C# and Visual Basic files
+[*.{cs,vb}]
+# Sort using directives with System.* appearing first
+dotnet_sort_system_directives_first = true
+# Avoid "this." unless necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+# C# specific formatting
+[*.cs]
+# Prefer var when the type is obvious
+csharp_style_var_for_built_in_types = false:none
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:none
+
+# Newline settings
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Set default behavior to normalize line endings
+* text=auto
+
+# C# code and project files
+*.cs       text diff=csharp
+*.csproj   text
+*.props    text
+*.targets  text
+*.resx     text
+*.config   text
+*.manifest text
+
+# Windows-specific files that require CRLF
+*.sln text eol=crlf
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Hide auto-generated designer files from GitHub diffs/language stats
+*.Designer.cs linguist-generated=true
+
+# Exclude binary files from normalization
+*.dll binary
+*.exe binary
+*.png binary
+*.jpg binary
+*.ico binary


### PR DESCRIPTION
Adds config files to standardize formatting and line endings across contributors.

**.gitattributes**
- `* text=auto` default
- CRLF forced for `*.sln`, `*.bat`, `*.cmd`, `*.ps1`
- `*.Designer.cs` marked `linguist-generated=true` (hides from GitHub diffs/stats)
- Binary: `*.dll`, `*.exe`, `*.png`, `*.jpg`, `*.ico`

**.editorconfig**
- 4-space indent for C#, 2-space for XML/config/JSON
- LF default, CRLF override for Windows-specific files
- C# style: sort `System.*` usings first, `var` when apparent, braces on new lines

May follow up with `git add --renormalize .` to normalize existing files. Feel free to edit as needed.