### PR TITLE
Verify WFP audit policy on startup when lockdown is persisted

### DIFF
--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -255,6 +255,19 @@ namespace MinimalFirewall
             {
                 _eventListenerService.EnableAuditing();
                 _eventListenerService.Start();
+
+                if (!AdminTaskService.IsAuditPolicyEnabled())
+                {
+                    _activityLogger.LogDebug("[Startup] Lockdown is on but WFP audit policy is not enabled. Connection popups will not work until this is resolved.");
+                    MessageBox.Show(this,
+                        "Lockdown Mode is active, but Windows Security Auditing could not be verified as enabled.\n\n" +
+                        "Blocked-connection popups and the dashboard will not work until this is resolved.\n\n" +
+                        "Potential Causes:\n" +
+                        "1. A local or domain Group Policy is preventing audit subcategory changes.\n" +
+                        "2. Other security software is blocking this action.\n\n" +
+                        "Existing firewall rules will continue to apply normally.",
+                        "Audit Policy Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
             }
             else
             {


### PR DESCRIPTION
**Parity fix:** `ToggleLockdown` verifies `IsAuditPolicyEnabled()` after setting the policy, but the `OnShown` path that re-arms auditing for an already-locked-down session does not. When the Filtering Platform Connection subcategory is blocked by GPO or reset externally between sessions, `5157` events never reach `FirewallEventListenerService`, so the Dashboard and popups go silent with no indication.

Adds the same check in `MainForm.OnShown` after `EnableAuditing()` + `Start()`, with a log entry and a warning dialog. Does not revert `SetDefaultOutboundAction` — persisted lockdown state is preserved and explicit rules remain in effect.