### PR TITLE
Possible fix for #117: allow Dnscache TCP (DoH / DoT / TCP-53) in Lockdown Mode

### DIFF
--- a/src/FirewallActionService.cs
+++ b/src/FirewallActionService.cs
@@ -552,6 +552,17 @@ namespace MinimalFirewall
                 "53", "*", 
                 enable
             );
+
+            // DNS Client (Dnscache) - TCP for DoH (443), DoT (853), and TCP/53 fallback
+            ManageSystemRule(
+                "Minimal Firewall System - DNS Client (TCP)",
+                "Allows the DNS Client (Dnscache) to use DNS-over-HTTPS, DNS-over-TLS, and TCP DNS fallback.",
+                "svchost.exe",
+                "Dnscache",
+                6,
+                "53,443,853", "*",
+                enable
+            );
         }
 
         public void ProcessPendingConnection(PendingConnectionViewModel pending, string decision, TimeSpan duration = default, bool trustPublisher = false)


### PR DESCRIPTION
The existing Lockdown system rule for the DNS Client only covers UDP/53, which may be why DNS-over-HTTPS traffic from Dnscache (TCP/443) gets dropped under the default-block outbound policy, as described in #117.

Adds a second outbound system rule for svchost.exe + service Dnscache, TCP, remote ports 53,443,853. Existing UDP/53 rule is left as-is.

I'm not sure this is the approach you'd want. Widening the existing rule or pinning DoH server IPs could also make sense idk.