### PR TITLE
Fix #112: Harden shutdown paths to prevent ObjectDisposedException and UI deadlock

### DIFF
--- a/src/AuditControl.cs
+++ b/src/AuditControl.cs
@@ -112,7 +112,14 @@ namespace MinimalFirewall
         {
             if (this.InvokeRequired)
             {
-                this.Invoke(() => OnStatusTextChanged(text));
+                // BeginInvoke (not Invoke) so worker thread never blocks on UI thread;
+                // prevents shutdown deadlock when UI is in BackgroundTaskService.Dispose's _worker.Wait.
+                if (!this.IsDisposed && this.IsHandleCreated)
+                {
+                    try { this.BeginInvoke(() => OnStatusTextChanged(text)); }
+                    catch (ObjectDisposedException) { }
+                    catch (InvalidOperationException) { }
+                }
                 return;
             }
             statusLabel.Text = text;

--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -82,19 +82,26 @@ namespace MinimalFirewall
             if (_isDisposed) return;
 
             Interlocked.Increment(ref _outstandingWork);
+            bool added = false;
             try
             {
                 _taskQueue.Add(task);
-                SafeInvoke(QueueCountChanged, _taskQueue.Count);
+                added = true;
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) { }
+
+            if (!added)
             {
                 Interlocked.Decrement(ref _outstandingWork);
+                SignalIdleIfQuiescent();
+                return;
             }
-            catch (InvalidOperationException)
-            {
-                Interlocked.Decrement(ref _outstandingWork);
-            }
+
+            // Count post-Add can throw if Dispose() raced; task is genuinely queued
+            // either way, so don't unwind the increment.
+            try { SafeInvoke(QueueCountChanged, _taskQueue.Count); }
+            catch (ObjectDisposedException) { }
         }
 
         private async Task ProcessQueueAsync()
@@ -109,7 +116,7 @@ namespace MinimalFirewall
                     // If queue is empty, we wait UP TO 1500ms for a new item.
                     // If an item arrives, TryTake returns true immediately (no lag).
                     // If 1500ms passes, it returns false, and we update status to "Ready".
-                    if (_taskQueue.Count == 0)
+                    if (SafeQueueCount() == 0)
                     {
                         if (!_taskQueue.TryTake(out task, 1500, _cancellationTokenSource.Token))
                         {
@@ -140,6 +147,10 @@ namespace MinimalFirewall
             catch (InvalidOperationException)
             {
                 // Graceful shutdown via CompleteAdding() once queue is drained.
+            }
+            catch (ObjectDisposedException)
+            {
+                // Catastrophic-shutdown path: queue disposed while worker still running.
             }
         }
 
@@ -177,18 +188,22 @@ namespace MinimalFirewall
             }
             finally
             {
-                if (result.RequiresCacheInvalidation && _taskQueue.Count == 0)
+                // Read once via SafeQueueCount so a post-Dispose race doesn't skip
+                // the decrement / idle signal at the bottom of this finally.
+                int queueCount = SafeQueueCount();
+
+                if (result.RequiresCacheInvalidation && queueCount == 0)
                 {
                     _dataService.InvalidateRuleCache();
                     _activityLogger.LogDebug($"[Cache] Invalidated MFW Rules cache after task batch completed.");
                 }
 
-                if (result.RequiresWildcardRefresh && _taskQueue.Count == 0)
+                if (result.RequiresWildcardRefresh && queueCount == 0)
                 {
                     SafeInvoke(WildcardRulesChanged);
                 }
 
-                SafeInvoke(QueueCountChanged, _taskQueue.Count);
+                SafeInvoke(QueueCountChanged, queueCount);
                 Interlocked.Decrement(ref _outstandingWork);
                 SignalIdleIfQuiescent();
             }

--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -78,7 +78,8 @@ namespace MinimalFirewall
 
         public void EnqueueTask(FirewallTask task)
         {
-            if (_isDisposed || _taskQueue.IsAddingCompleted) return;
+            // IsAddingCompleted itself throws if Dispose() raced ahead; rely on catches.
+            if (_isDisposed) return;
 
             Interlocked.Increment(ref _outstandingWork);
             try

--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -144,13 +144,14 @@ namespace MinimalFirewall
             {
                 // Graceful shutdown via cancellation token.
             }
-            catch (InvalidOperationException)
-            {
-                // Graceful shutdown via CompleteAdding() once queue is drained.
-            }
             catch (ObjectDisposedException)
             {
                 // Catastrophic-shutdown path: queue disposed while worker still running.
+                // Must precede InvalidOperationException (it's a subclass).
+            }
+            catch (InvalidOperationException)
+            {
+                // Graceful shutdown via CompleteAdding() once queue is drained.
             }
         }
 
@@ -247,6 +248,12 @@ namespace MinimalFirewall
         private void SafeInvoke<T>(Action<T>? action, T param)
         {
             try { action?.Invoke(param); } catch { /* Ignore UI update errors */ }
+        }
+
+        private int SafeQueueCount()
+        {
+            try { return _taskQueue.Count; }
+            catch (ObjectDisposedException) { return 0; }
         }
 
         // Map the TaskType enum 

--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -68,22 +68,18 @@ namespace MinimalFirewall
 
         public void EnqueueTask(FirewallTask task)
         {
+            // Don't probe _taskQueue state outside the try: IsAddingCompleted
+            // can itself throw if Dispose() raced ahead. Catches cover late
+            // callbacks from watchers / debounce timers post-Dispose.
             if (_isDisposed) return;
 
             try
             {
-                if (!_taskQueue.IsAddingCompleted)
-                {
-                    _taskQueue.Add(task);
-                    SafeInvoke(QueueCountChanged, _taskQueue.Count);
-                }
+                _taskQueue.Add(task);
+                SafeInvoke(QueueCountChanged, _taskQueue.Count);
             }
-            catch (ObjectDisposedException)
-            {
-            }
-            catch (InvalidOperationException)
-            {
-            }
+            catch (ObjectDisposedException) { }
+            catch (InvalidOperationException) { }
         }
 
         private async Task ProcessQueueAsync()

--- a/src/MainForm.Designer.cs
+++ b/src/MainForm.Designer.cs
@@ -36,12 +36,15 @@ namespace MinimalFirewall
             {
                 _trayBlinkTimer?.Dispose();
                 _autoRefreshTimer?.Dispose();
+                // Order matters: view model -> producers -> consumer queue.
+                // In-flight watcher callbacks racing past this are guarded in EnqueueTask.
+                _mainViewModel?.Dispose();
+                _firewallSentryService?.Dispose();
+                _eventListenerService?.Dispose();
                 _backgroundTaskService?.Dispose();
                 _lockedGreenIcon?.Dispose();
                 _unlockedWhiteIcon?.Dispose();
                 _refreshWhiteIcon?.Dispose();
-                _firewallSentryService?.Dispose();
-                _eventListenerService?.Dispose();
                 _defaultTrayIcon?.Dispose();
                 _unlockedTrayIcon?.Dispose();
                 _alertTrayIcon?.Dispose();

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -80,7 +80,7 @@ namespace MinimalFirewall
             _firewallSentryService.RuleSetChanged += OnRuleSetChanged;
             _eventListenerService.PendingConnectionDetected += OnPendingConnectionDetected;
 
-            _backgroundTaskService.StatusChanged += (text) => StatusTextChanged?.Invoke(text);
+            _backgroundTaskService.StatusChanged += OnBackgroundStatusChanged;
 
             DebouncedSentryRefresh(null);
         }
@@ -568,6 +568,11 @@ namespace MinimalFirewall
             _backgroundTaskService.EnqueueTask(new FirewallTask(FirewallTaskType.ApplyApplicationRule, payload, $"Applying {action} to {Path.GetFileName(appPath)}"));
         }
 
+        private void OnBackgroundStatusChanged(string text)
+        {
+            StatusTextChanged?.Invoke(text);
+        }
+
         private void OnRuleSetChanged()
         {
             ClearRulesCache();
@@ -726,8 +731,10 @@ namespace MinimalFirewall
         {
             // Unsubscribe before disposing the timer; residual in-flight
             // callbacks are caught in OnRuleSetChanged and EnqueueTask.
+            // StatusChanged unsub avoids worker -> UI Invoke deadlock during shutdown.
             _firewallSentryService.RuleSetChanged -= OnRuleSetChanged;
             _eventListenerService.PendingConnectionDetected -= OnPendingConnectionDetected;
+            _backgroundTaskService.StatusChanged -= OnBackgroundStatusChanged;
             _sentryRefreshDebounceTimer?.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -16,7 +16,7 @@ using System.Windows.Forms;
 
 namespace MinimalFirewall
 {
-    public class MainViewModel : ObservableViewModel
+    public class MainViewModel : ObservableViewModel, IDisposable
     {
         private readonly FirewallRuleService _firewallRuleService;
         private readonly WildcardRuleService _wildcardRuleService;
@@ -576,7 +576,8 @@ namespace MinimalFirewall
                 return;
             }
 
-            _sentryRefreshDebounceTimer?.Change(1000, Timeout.Infinite);
+            try { _sentryRefreshDebounceTimer?.Change(1000, Timeout.Infinite); }
+            catch (ObjectDisposedException) { } // timer disposed during shutdown
         }
 
         private async void DebouncedSentryRefresh(object? state)
@@ -719,6 +720,16 @@ namespace MinimalFirewall
                     MessageBoxButtons.OK,
                     MsgIcon.Error);
             }
+        }
+
+        public void Dispose()
+        {
+            // Unsubscribe before disposing the timer; residual in-flight
+            // callbacks are caught in OnRuleSetChanged and EnqueueTask.
+            _firewallSentryService.RuleSetChanged -= OnRuleSetChanged;
+            _eventListenerService.PendingConnectionDetected -= OnPendingConnectionDetected;
+            _sentryRefreshDebounceTimer?.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Addresses #112.

**Changes**
- Reordered `MainForm` disposal so producers (`FirewallSentryService`, `EventListenerService`) stop before the consumer queue is drained.
- Hardened `EnqueueTask` against post-disposal queue access; added `SafeQueueCount()` helper to prevent counter corruption if `BlockingCollection.Count` throws.
- Converted `AuditControl` status updates from synchronous `Invoke` to `BeginInvoke` to avoid a potential worker/UI thread deadlock during shutdown.
- Made `MainViewModel` disposable and explicitly unsubscribed `StatusChanged` so residual worker callbacks don't fire into disposed UI.

**Notes**
- The commit history is a bit messy due to my difficulties with git. The diff itself is clean.
- Builds cleanly.
- No new nullable warnings introduced.