### PR TITLE
Add Date Added column to Rules tab

### DIFF
--- a/src/Appdata.cs
+++ b/src/Appdata.cs
@@ -35,7 +35,8 @@ namespace MinimalFirewall
             "debug_log.txt",
             "changelog.json",
             "uwp_apps.json",
-            "trusted_publishers.json"
+            "trusted_publishers.json",
+            "rule_timestamps.json"
         };
 
         public static void EnsureStorageDirectoryExists()

--- a/src/DataModels.cs
+++ b/src/DataModels.cs
@@ -99,6 +99,7 @@ public class AdvancedRuleViewModel
     public WildcardRule? WildcardDefinition { get; set; }
     public string InterfaceTypes { get; set; } = string.Empty;
     public string IcmpTypesAndCodes { get; set; } = string.Empty;
+    public DateTime? DateAdded { get; set; }
 
     // Checks if all firewall-relevant properties match (Case-Insensitive for strings)
     public bool HasSameSettings(AdvancedRuleViewModel? other)

--- a/src/FirewallDataService.cs
+++ b/src/FirewallDataService.cs
@@ -69,16 +69,19 @@ namespace MinimalFirewall
                 }
 
                 // Stamp first-seen times, prune stale entries, persist if dirty.
+                // First refresh after install treats all observed rules as baseline (Unknown).
                 var now = DateTime.UtcNow;
+                bool isBaseline = _ruleTimestampService.IsBaselineSession;
                 var activeNames = new List<string>(mfwRules.Count);
                 foreach (var rule in mfwRules)
                 {
                     if (string.IsNullOrEmpty(rule.Name)) continue;
-                    rule.DateAdded = _ruleTimestampService.EnsureStamped(rule.Name, now);
+                    rule.DateAdded = _ruleTimestampService.EnsureStamped(rule.Name, now, isBaseline);
                     activeNames.Add(rule.Name);
                 }
                 _ruleTimestampService.PruneTo(activeNames);
                 _ruleTimestampService.Flush();
+                if (isBaseline) _ruleTimestampService.EndBaselineSession();
 
                 return mfwRules;
             }, token);

--- a/src/FirewallDataService.cs
+++ b/src/FirewallDataService.cs
@@ -14,11 +14,12 @@ namespace MinimalFirewall
 {
     public enum MfwRuleStatus { None, MfwAllow, MfwBlock }
 
-    public class FirewallDataService(FirewallRuleService firewallRuleService, WildcardRuleService wildcardRuleService, UwpService uwpService)
+    public class FirewallDataService(FirewallRuleService firewallRuleService, WildcardRuleService wildcardRuleService, UwpService uwpService, RuleTimestampService ruleTimestampService)
     {
         private readonly FirewallRuleService _firewallRuleService = firewallRuleService;
         private readonly WildcardRuleService _wildcardRuleService = wildcardRuleService;
         private readonly UwpService _uwpService = uwpService;
+        private readonly RuleTimestampService _ruleTimestampService = ruleTimestampService;
         private readonly MemoryCache _localCache = new(new MemoryCacheOptions());
         private const string ServicesCacheKey = "ServicesList";
         private const string MfwRulesCacheKey = "MfwRulesList";
@@ -66,6 +67,19 @@ namespace MinimalFirewall
                 {
                     return [];
                 }
+
+                // Stamp first-seen times, prune stale entries, persist if dirty.
+                var now = DateTime.UtcNow;
+                var activeNames = new List<string>(mfwRules.Count);
+                foreach (var rule in mfwRules)
+                {
+                    if (string.IsNullOrEmpty(rule.Name)) continue;
+                    rule.DateAdded = _ruleTimestampService.EnsureStamped(rule.Name, now);
+                    activeNames.Add(rule.Name);
+                }
+                _ruleTimestampService.PruneTo(activeNames);
+                _ruleTimestampService.Flush();
+
                 return mfwRules;
             }, token);
         }
@@ -157,7 +171,8 @@ namespace MinimalFirewall
                 IsEnabled = group.TrueForAll(r => r.IsEnabled),
                 Profiles = firstRule.Profiles,
                 Grouping = firstRule.Grouping ?? "",
-                Description = firstRule.Description ?? ""
+                Description = firstRule.Description ?? "",
+                DateAdded = group.Where(r => r.DateAdded.HasValue).Min(r => (DateTime?)r.DateAdded)
             };
 
             bool hasInAllow = group.Exists(r => r.Status == "Allow" && r.Direction.HasFlag(Directions.Incoming));

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -32,6 +32,7 @@ namespace MinimalFirewall
         private UserActivityLogger _activityLogger;
         private WildcardRuleService _wildcardRuleService;
         private ForeignRuleTracker _foreignRuleTracker;
+        private RuleTimestampService _ruleTimestampService;
         private AppSettings _appSettings;
         private StartupService _startupService;
         private FirewallGroupManager _groupManager;
@@ -141,9 +142,10 @@ namespace MinimalFirewall
             _activityLogger = new UserActivityLogger { IsEnabled = _appSettings.IsLoggingEnabled };
             _wildcardRuleService = new WildcardRuleService();
             _foreignRuleTracker = new ForeignRuleTracker();
+            _ruleTimestampService = new RuleTimestampService();
 
             var uwpService = new UwpService(_firewallRuleService);
-            _dataService = new FirewallDataService(_firewallRuleService, _wildcardRuleService, uwpService);
+            _dataService = new FirewallDataService(_firewallRuleService, _wildcardRuleService, uwpService, _ruleTimestampService);
             _firewallSentryService = new FirewallSentryService(_firewallRuleService);
             var trafficMonitorViewModel = new TrafficMonitorViewModel();
 

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -229,6 +229,7 @@ namespace MinimalFirewall
 
         private void AddRuleAndRefresh(AggregatedRuleViewModel newRule)
         {
+            newRule.DateAdded ??= DateTime.UtcNow;
             AllAggregatedRules.Add(newRule);
             ApplyRulesFilters(string.Empty, new HashSet<RuleType>(), false);
         }

--- a/src/RuleTimestampService.cs
+++ b/src/RuleTimestampService.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MinimalFirewall
+{
+    public class RuleTimestampService
+    {
+        private readonly string _path;
+        private Dictionary<string, DateTime> _timestamps = new(StringComparer.OrdinalIgnoreCase);
+        private readonly object _lock = new();
+        private bool _dirty;
+
+        public RuleTimestampService()
+        {
+            _path = ConfigPathManager.GetConfigPath("rule_timestamps.json");
+            Load();
+        }
+
+        private void Load()
+        {
+            lock (_lock)
+            {
+                try
+                {
+                    if (!File.Exists(_path)) return;
+                    string json = File.ReadAllText(_path);
+                    if (string.IsNullOrWhiteSpace(json)) return;
+
+                    var loaded = JsonSerializer.Deserialize(json, RuleTimestampJsonContext.Default.DictionaryStringDateTime);
+                    if (loaded != null)
+                    {
+                        _timestamps = new Dictionary<string, DateTime>(loaded, StringComparer.OrdinalIgnoreCase);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[ERROR] Failed to load rule timestamps: {ex.Message}");
+                    _timestamps = new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        // Returns existing stamp if known, otherwise records and returns the supplied stamp.
+        public DateTime EnsureStamped(string ruleName, DateTime stamp)
+        {
+            if (string.IsNullOrEmpty(ruleName)) return stamp;
+            lock (_lock)
+            {
+                if (_timestamps.TryGetValue(ruleName, out var existing)) return existing;
+                _timestamps[ruleName] = stamp;
+                _dirty = true;
+                return stamp;
+            }
+        }
+
+        public DateTime? Get(string ruleName)
+        {
+            if (string.IsNullOrEmpty(ruleName)) return null;
+            lock (_lock)
+            {
+                return _timestamps.TryGetValue(ruleName, out var ts) ? ts : null;
+            }
+        }
+
+        public void Set(string ruleName, DateTime stamp)
+        {
+            if (string.IsNullOrEmpty(ruleName)) return;
+            lock (_lock)
+            {
+                _timestamps[ruleName] = stamp;
+                _dirty = true;
+            }
+        }
+
+        public void PruneTo(IEnumerable<string> activeRuleNames)
+        {
+            var active = new HashSet<string>(activeRuleNames, StringComparer.OrdinalIgnoreCase);
+            lock (_lock)
+            {
+                var toRemove = _timestamps.Keys.Where(k => !active.Contains(k)).ToList();
+                if (toRemove.Count == 0) return;
+                foreach (var k in toRemove) _timestamps.Remove(k);
+                _dirty = true;
+            }
+        }
+
+        public void Flush()
+        {
+            lock (_lock)
+            {
+                if (!_dirty) return;
+                try
+                {
+                    string json = JsonSerializer.Serialize(_timestamps, RuleTimestampJsonContext.Default.DictionaryStringDateTime);
+                    string tempPath = _path + ".tmp";
+                    File.WriteAllText(tempPath, json);
+                    File.Move(tempPath, _path, overwrite: true);
+                    _dirty = false;
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[ERROR] Failed to save rule timestamps: {ex.Message}");
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                if (_timestamps.Count == 0) return;
+                _timestamps.Clear();
+                _dirty = true;
+            }
+            Flush();
+        }
+    }
+
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    [JsonSerializable(typeof(Dictionary<string, DateTime>))]
+    internal partial class RuleTimestampJsonContext : JsonSerializerContext { }
+}

--- a/src/RuleTimestampService.cs
+++ b/src/RuleTimestampService.cs
@@ -14,11 +14,25 @@ namespace MinimalFirewall
         private Dictionary<string, DateTime> _timestamps = new(StringComparer.OrdinalIgnoreCase);
         private readonly object _lock = new();
         private bool _dirty;
+        private bool _isBaselineSession;
 
         public RuleTimestampService()
         {
             _path = ConfigPathManager.GetConfigPath("rule_timestamps.json");
+            _isBaselineSession = !File.Exists(_path);
             Load();
+        }
+
+        // True until the first refresh has flushed; rules observed during this window are
+        // recorded with a sentinel so they display as Unknown rather than as the install-time stamp.
+        public bool IsBaselineSession
+        {
+            get { lock (_lock) { return _isBaselineSession; } }
+        }
+
+        public void EndBaselineSession()
+        {
+            lock (_lock) { _isBaselineSession = false; }
         }
 
         private void Load()
@@ -45,16 +59,22 @@ namespace MinimalFirewall
             }
         }
 
-        // Returns existing stamp if known, otherwise records and returns the supplied stamp.
-        public DateTime EnsureStamped(string ruleName, DateTime stamp)
+        // Returns existing stamp if known, otherwise records the supplied stamp.
+        // When treatAsBaseline is true and the rule is unseen, stores DateTime.MinValue
+        // as an Unknown sentinel and returns null. MinValue is also translated to null on read.
+        public DateTime? EnsureStamped(string ruleName, DateTime stamp, bool treatAsBaseline = false)
         {
-            if (string.IsNullOrEmpty(ruleName)) return stamp;
+            if (string.IsNullOrEmpty(ruleName)) return treatAsBaseline ? null : stamp;
             lock (_lock)
             {
-                if (_timestamps.TryGetValue(ruleName, out var existing)) return existing;
-                _timestamps[ruleName] = stamp;
+                if (_timestamps.TryGetValue(ruleName, out var existing))
+                {
+                    return existing == DateTime.MinValue ? null : existing;
+                }
+                var toStore = treatAsBaseline ? DateTime.MinValue : stamp;
+                _timestamps[ruleName] = toStore;
                 _dirty = true;
-                return stamp;
+                return toStore == DateTime.MinValue ? null : toStore;
             }
         }
 
@@ -63,7 +83,9 @@ namespace MinimalFirewall
             if (string.IsNullOrEmpty(ruleName)) return null;
             lock (_lock)
             {
-                return _timestamps.TryGetValue(ruleName, out var ts) ? ts : null;
+                if (_timestamps.TryGetValue(ruleName, out var ts) && ts != DateTime.MinValue)
+                    return ts;
+                return null;
             }
         }
 

--- a/src/RulesControl.Designer.cs
+++ b/src/RulesControl.Designer.cs
@@ -36,6 +36,7 @@ namespace MinimalFirewall
         private System.Windows.Forms.DataGridViewTextBoxColumn advProfilesColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn advGroupingColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn advDescColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn dateAddedColumn;
         private System.Windows.Forms.FlowLayoutPanel filterPanel;
         private System.Windows.Forms.CheckBox programFilterCheckBox;
         private System.Windows.Forms.CheckBox serviceFilterCheckBox;
@@ -100,6 +101,7 @@ namespace MinimalFirewall
             this.advProfilesColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.advGroupingColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.advDescColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dateAddedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.filterPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.programFilterCheckBox = new System.Windows.Forms.CheckBox();
             this.serviceFilterCheckBox = new System.Windows.Forms.CheckBox();
@@ -300,7 +302,8 @@ namespace MinimalFirewall
             this.advServiceColumn,
             this.advProfilesColumn,
             this.advGroupingColumn,
-            this.advDescColumn});
+            this.advDescColumn,
+            this.dateAddedColumn});
             this.rulesDataGridView.ContextMenuStrip = this.rulesContextMenu;
             this.rulesDataGridView.EnableHeadersVisualStyles = false;
             this.rulesDataGridView.GridColor = System.Drawing.SystemColors.Control;
@@ -436,6 +439,15 @@ namespace MinimalFirewall
             this.advDescColumn.HeaderText = "Description";
             this.advDescColumn.Name = "advDescColumn";
             this.advDescColumn.ReadOnly = true;
+            // 
+            // dateAddedColumn
+            // 
+            this.dateAddedColumn.DataPropertyName = "DateAdded";
+            this.dateAddedColumn.DefaultCellStyle.Format = "yyyy-MM-dd HH:mm";
+            this.dateAddedColumn.FillWeight = 12F;
+            this.dateAddedColumn.HeaderText = "Date Added";
+            this.dateAddedColumn.Name = "dateAddedColumn";
+            this.dateAddedColumn.ReadOnly = true;
             // 
             // filterPanel
             // 

--- a/src/RulesControl.cs
+++ b/src/RulesControl.cs
@@ -155,6 +155,7 @@ namespace MinimalFirewall
                 _ when col == advProfilesColumn => rule.Profiles,
                 _ when col == advGroupingColumn => rule.Grouping,
                 _ when col == advDescColumn => rule.Description,
+                _ when col == dateAddedColumn => rule.DateAdded.HasValue ? rule.DateAdded.Value.ToLocalTime() : null,
                 _ => e.Value
             };
         }


### PR DESCRIPTION
Adds a sortable "Date Added" column (rightmost, after Description) backed by app-tracked first-seen timestamps persisted to `rule_timestamps.json`.

Windows Firewall has no creation-time API and Security Event 4946 needs admin + audit policy + has gaps, so app-tracked first-seen is the pragmatic choice. `RuleTimestampService` mirrors the `ForeignRuleTracker` pattern (locked dict, atomic temp+move write, source-gen JSON). `FirewallDataService` stamps + prunes on every fetch; aggregation propagates `MIN(DateAdded)`. Column appended at end so existing `RulesSortColumn` indices in saved settings still resolve.

Format is `YYYY-MM-DD HH:mm` (ISO 8601, no seconds).

**Baseline session**: first launch (no JSON yet) stores every observed rule with `DateTime.MinValue` sentinel → displayed empty, so years-old rules don't get falsely stamped with the install time. Subsequent rules get real timestamps.

**Optimistic UI**: `AddRuleAndRefresh` now does `newRule.DateAdded ??= DateTime.UtcNow` so wizard/popup rules show a date immediately instead of waiting for the next refresh.

Known limitations: externally renamed rule = treated as new; rule created in the ~1s window before the first refresh on a fresh install briefly shows `now` then reverts to empty.

---

Feel free to close if it's not a direction you want, I'll keep using it locally either way haha :)