### PR TITLE
add logging to silent exception handlers

### DIFF
--- a/src/AuditControl.cs
+++ b/src/AuditControl.cs
@@ -205,8 +205,9 @@ namespace MinimalFirewall
                         SortOrder.Ascending : SortOrder.Descending;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] ApplySearchFilter failed: {ex.Message}");
             }
         }
 

--- a/src/DarkModeCS.cs
+++ b/src/DarkModeCS.cs
@@ -870,7 +870,10 @@ namespace DarkModeForms
                 if (key?.GetValue("CurrentMajorVersionNumber") is int majorInt) return majorInt;
                 if (key?.GetValue("ProductName")?.ToString()?.Contains("Windows 1") == true) return 10;
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[WARN] WindowsVersion failed to read registry version: {ex.Message}");
+            }
             return 10;
         }
 

--- a/src/DashboardControl.cs
+++ b/src/DashboardControl.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Reflection;
 using System.Windows.Forms;
 using System.Text.Json;
+using System.Diagnostics;
 
 namespace MinimalFirewall
 {
@@ -71,7 +72,10 @@ namespace MinimalFirewall
                     }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[WARN] DashboardControl.Initialize failed to restore layout: {ex.Message}");
+            }
 
             splitContainer.SplitterMoved += SplitContainer_SplitterMoved;
 
@@ -521,7 +525,10 @@ namespace MinimalFirewall
                 string json = JsonSerializer.Serialize(settings);
                 File.WriteAllText(_layoutSettingsPath, json);
             }
-            catch { }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[WARN] DashboardControl.SplitContainer_SplitterMoved failed to save layout: {ex.Message}");
+            }
         }
 
         public class DashboardLayoutSettings

--- a/src/FirewallEventListenerService.cs
+++ b/src/FirewallEventListenerService.cs
@@ -424,7 +424,10 @@ namespace MinimalFirewall
                     if (normalizedDir.StartsWith(resolved, StringComparison.OrdinalIgnoreCase))
                         return true;
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[WARN] IsInExcludedFolder failed for excluded folder '{excludedFolder}': {ex.Message}");
+                }
             }
 
             return false;

--- a/src/FirewallRuleService.cs
+++ b/src/FirewallRuleService.cs
@@ -40,9 +40,10 @@ namespace MinimalFirewall
                     {
                         mappedList.Add(mapper(rule));
                     }
-                    catch
+                    catch (Exception ex)
                     {
                         // Ignore rules that fail to map
+                        Debug.WriteLine($"[WARN] GetAllRulesMapped: Failed to map firewall rule: {ex.Message}");
                     }
                     finally
                     {
@@ -220,7 +221,10 @@ namespace MinimalFirewall
                             keep = true;
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        Debug.WriteLine($"[WARN] GetRulesByPathAndDirection: Failed to inspect firewall rule: {ex.Message}");
+                    }
                     finally
                     {
                         if (!keep) Marshal.ReleaseComObject(rule);

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -639,8 +639,9 @@ namespace MinimalFirewall
                     BeginInvoke(new Action(ProcessNextPopup));
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                _activityLogger.LogException("Notifier_FormClosed", ex);
             }
             finally
             {

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -184,7 +184,10 @@ namespace MinimalFirewall
                     if (p.MainModule != null) path = p.MainModule.FileName;
                 }
                 catch (Win32Exception) { path = "N/A (Access Denied)"; }
-                catch { }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[WARN] ResolveProcessInfo failed to read main module for PID {pid}: {ex.Message}");
+                }
 
                 if (name.Equals("svchost", StringComparison.OrdinalIgnoreCase))
                 {
@@ -196,8 +199,9 @@ namespace MinimalFirewall
             {
                 return ("(Exited)", string.Empty, string.Empty);
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] ResolveProcessInfo failed for PID {pid}: {ex.Message}");
                 return ("Unknown", string.Empty, string.Empty);
             }
         }

--- a/src/NotifierForm.cs
+++ b/src/NotifierForm.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace MinimalFirewall
 {
@@ -120,8 +121,9 @@ namespace MinimalFirewall
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NotifierForm.OnLoad failed to restore layout: {ex.Message}");
             }
         }
 
@@ -149,8 +151,9 @@ namespace MinimalFirewall
                     trustPublisherCheckBox.Visible = false;
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NotifierForm.OnShown failed to load publisher info: {ex.Message}");
                 trustPublisherCheckBox.Visible = false;
             }
         }
@@ -174,8 +177,9 @@ namespace MinimalFirewall
                     File.WriteAllText(_layoutSettingsPath, json);
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NotifierForm.OnFormClosing failed to save layout: {ex.Message}");
             }
 
             base.OnFormClosing(e);
@@ -278,8 +282,9 @@ namespace MinimalFirewall
                     copyDetailsButton.Text = "📋";
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NotifierForm.copyDetailsButton_Click failed: {ex.Message}");
             }
         }
 

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Net;
@@ -155,7 +156,10 @@ namespace MinimalFirewall
                     }
                 }
             }
-            catch {  }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[WARN] PathResolver failed to build DOS device map: {ex.Message}");
+            }
 
             var specialFolders = new[]
             {
@@ -179,7 +183,10 @@ namespace MinimalFirewall
                         _envVarMap[path] = envVar;
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[WARN] PathResolver failed to map special folder {folder}: {ex.Message}");
+                }
             }
         }
 
@@ -204,8 +211,9 @@ namespace MinimalFirewall
             {
                 return Environment.ExpandEnvironmentVariables(environmentPath);
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] ConvertFromEnvironmentPath failed: {ex.Message}");
                 return environmentPath;
             }
         }
@@ -218,8 +226,9 @@ namespace MinimalFirewall
             {
                 expandedPath = Environment.ExpandEnvironmentVariables(path);
             }
-            catch
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NormalizePath failed to expand environment variables: {ex.Message}");
                 return path;
             }
 
@@ -238,8 +247,9 @@ namespace MinimalFirewall
                         }
                     }
                 }
-                catch
+                catch (Exception ex)
                 {
+                    Debug.WriteLine($"[WARN] NormalizePath failed to resolve actual file casing: {ex.Message}");
                 }
             }
 
@@ -253,8 +263,9 @@ namespace MinimalFirewall
                 string basePath = AppContext.BaseDirectory;
                 return Path.GetFullPath(Path.Combine(basePath, expandedPath));
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Debug.WriteLine($"[WARN] NormalizePath failed to get full path: {ex.Message}");
                 return path;
             }
         }


### PR DESCRIPTION
Replaced several empty catch blocks with `Debug.WriteLine` / `LogException` to prevent silent failures.

No logic changes; strictly added diagnostic visibility for layout persistence, registry reads, path normalization, and UI events. Added `System.Diagnostics` imports where required.

Happy to adjust or drop if there's a preferred logging approach.