### PR TITLE
feat: show origin for auto-allowed rules

### DIFF
--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -262,7 +262,7 @@ namespace MinimalFirewall
             var map = new Dictionary<FirewallTaskType, IFirewallTaskHandler>();
             // Standard Rule Handlers 
             map[FirewallTaskType.ApplyApplicationRule] = new ActionHandler<ApplyApplicationRulePayload>(
-                p => _actionsService.ApplyApplicationRuleChange(p.AppPaths, p.Action, p.WildcardSourcePath), TaskResult.CacheOnly);
+                p => _actionsService.ApplyApplicationRuleChange(p.AppPaths, p.Action, p.WildcardSourcePath, p.AutoAllowedPublisher), TaskResult.CacheOnly);
             map[FirewallTaskType.ApplyServiceRule] = new ActionHandler<ApplyServiceRulePayload>(
                 p => _actionsService.ApplyServiceRuleChange(p.ServiceName, p.Action, p.AppPath), TaskResult.CacheOnly);
             map[FirewallTaskType.ApplyUwpRule] = new ActionHandler<ApplyUwpRulePayload>(

--- a/src/DataModels.cs
+++ b/src/DataModels.cs
@@ -100,6 +100,7 @@ public class AdvancedRuleViewModel
     public string InterfaceTypes { get; set; } = string.Empty;
     public string IcmpTypesAndCodes { get; set; } = string.Empty;
     public DateTime? DateAdded { get; set; }
+    public string AutoAllowedPublisher { get; set; } = string.Empty;
 
     // Checks if all firewall-relevant properties match (Case-Insensitive for strings)
     public bool HasSameSettings(AdvancedRuleViewModel? other)
@@ -292,7 +293,7 @@ public class FirewallTask
 }
 
 // Payload DTOs converted to records for Immutability and built-in ToString() logging
-public record ApplyApplicationRulePayload { public List<string> AppPaths { get; init; } = []; public string Action { get; init; } = ""; public string? WildcardSourcePath { get; init; } }
+public record ApplyApplicationRulePayload { public List<string> AppPaths { get; init; } = []; public string Action { get; init; } = ""; public string? WildcardSourcePath { get; init; } public string? AutoAllowedPublisher { get; init; } }
 public record ApplyServiceRulePayload { public string ServiceName { get; init; } = ""; public string Action { get; init; } = ""; public string? AppPath { get; init; } }
 public record ApplyUwpRulePayload { public List<UwpApp> UwpApps { get; init; } = []; public string Action { get; init; } = ""; }
 public record DeleteRulesPayload { public List<string> RuleIdentifiers { get; init; } = []; }

--- a/src/FirewallActionService.cs
+++ b/src/FirewallActionService.cs
@@ -161,7 +161,7 @@ namespace MinimalFirewall
             }
         }
 
-        public void ApplyApplicationRuleChange(List<string> appPaths, string action, string? wildcardSourcePath = null)
+        public void ApplyApplicationRuleChange(List<string> appPaths, string action, string? wildcardSourcePath = null, string? autoAllowedPublisher = null)
         {
             var normalizedAppPaths = appPaths.Select(PathResolver.NormalizePath).Where(p => !string.IsNullOrEmpty(p)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             if (action.StartsWith("Allow", StringComparison.OrdinalIgnoreCase))
@@ -201,8 +201,19 @@ namespace MinimalFirewall
                 string appName = Path.GetFileNameWithoutExtension(appPath);
                 void createRule(string baseName, Directions dir, Actions act)
                 {
-                    string description = string.IsNullOrEmpty(wildcardSourcePath) ?
-                        "" : $"{MFWConstants.WildcardDescriptionPrefix}{wildcardSourcePath}]";
+                    string description;
+                    if (!string.IsNullOrEmpty(wildcardSourcePath))
+                    {
+                        description = $"{MFWConstants.WildcardDescriptionPrefix}{wildcardSourcePath}]";
+                    }
+                    else if (!string.IsNullOrEmpty(autoAllowedPublisher))
+                    {
+                        description = $"{MFWConstants.AutoAllowPublisherPrefix}{autoAllowedPublisher}]";
+                    }
+                    else
+                    {
+                        description = "";
+                    }
                     CreateApplicationRule(baseName, appPath, dir, act, ProtocolTypes.Any.Value, description);
                 }
 

--- a/src/FirewallDataService.cs
+++ b/src/FirewallDataService.cs
@@ -175,7 +175,8 @@ namespace MinimalFirewall
                 Profiles = firstRule.Profiles,
                 Grouping = firstRule.Grouping ?? "",
                 Description = firstRule.Description ?? "",
-                DateAdded = group.Where(r => r.DateAdded.HasValue).Min(r => (DateTime?)r.DateAdded)
+                DateAdded = group.Where(r => r.DateAdded.HasValue).Min(r => (DateTime?)r.DateAdded),
+                AutoAllowedPublisher = group.Select(r => r.AutoAllowedPublisher).FirstOrDefault(p => !string.IsNullOrEmpty(p)) ?? ""
             };
 
             bool hasInAllow = group.Exists(r => r.Status == "Allow" && r.Direction.HasFlag(Directions.Incoming));
@@ -336,11 +337,22 @@ namespace MinimalFirewall
             var rawProtocol = rule.Protocol;
 
             string appName = string.IsNullOrEmpty(rawAppName) ? string.Empty : rawAppName;
+            string rawDescription = rule.Description ?? "N/A";
+            string autoAllowedPublisher = string.Empty;
+            if (rawDescription.StartsWith(MFWConstants.AutoAllowPublisherPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                int endIdx = rawDescription.IndexOf(']', MFWConstants.AutoAllowPublisherPrefix.Length);
+                if (endIdx > 0)
+                {
+                    autoAllowedPublisher = rawDescription.Substring(MFWConstants.AutoAllowPublisherPrefix.Length, endIdx - MFWConstants.AutoAllowPublisherPrefix.Length);
+                }
+                rawDescription = string.Empty;
+            }
 
             return new AdvancedRuleViewModel
             {
                 Name = rule.Name ?? "Unnamed Rule",
-                Description = rule.Description ?? "N/A",
+                Description = rawDescription,
                 IsEnabled = rule.Enabled,
                 Status = rule.Action == NET_FW_ACTION_.NET_FW_ACTION_ALLOW ? "Allow" : "Block",
                 Direction = (Directions)rule.Direction,
@@ -355,7 +367,8 @@ namespace MinimalFirewall
                 Profiles = GetProfileString(rule.Profiles),
                 Grouping = rule.Grouping ?? string.Empty,
                 InterfaceTypes = rule.InterfaceTypes ?? "All",
-                IcmpTypesAndCodes = rule.IcmpTypesAndCodes ?? ""
+                IcmpTypesAndCodes = rule.IcmpTypesAndCodes ?? "",
+                AutoAllowedPublisher = autoAllowedPublisher
             };
         }
 

--- a/src/FirewallEventListenerService.cs
+++ b/src/FirewallEventListenerService.cs
@@ -395,7 +395,8 @@ namespace MinimalFirewall
                 var appPayload = new ApplyApplicationRulePayload
                 {
                     AppPaths = new List<string> { appPath },
-                    Action = allowAction
+                    Action = allowAction,
+                    AutoAllowedPublisher = matchedPublisher
                 };
                 BackgroundTaskService.EnqueueTask(new FirewallTask(FirewallTaskType.ApplyApplicationRule, appPayload));
                 return true;

--- a/src/MFWConstants.cs
+++ b/src/MFWConstants.cs
@@ -7,6 +7,7 @@ namespace MinimalFirewall
         public const string WildcardRuleGroup = "Minimal Firewall (Wildcard) - MFW";
         public const string WildcardDescriptionPrefix = "MFW_Wildcard_Path:[";
         public const string UwpDescriptionPrefix = "UWP App; PFN=";
+        public const string AutoAllowPublisherPrefix = "MFW_AutoAllow_Publisher:[";
         public const string MfwRuleSuffix = " - MFW";
     }
 }

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -254,6 +254,8 @@ namespace MinimalFirewall
                 11 => rule => rule.Profiles,
                 12 => rule => rule.Grouping,
                 13 => rule => rule.Description,
+                14 => rule => rule.DateAdded ?? DateTime.MinValue,
+                15 => rule => rule.AutoAllowedPublisher,
                 _ => rule => rule.Name,
             };
         }

--- a/src/RulesControl.Designer.cs
+++ b/src/RulesControl.Designer.cs
@@ -37,6 +37,7 @@ namespace MinimalFirewall
         private System.Windows.Forms.DataGridViewTextBoxColumn advGroupingColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn advDescColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn dateAddedColumn;
+        private System.Windows.Forms.DataGridViewTextBoxColumn autoAllowedColumn;
         private System.Windows.Forms.FlowLayoutPanel filterPanel;
         private System.Windows.Forms.CheckBox programFilterCheckBox;
         private System.Windows.Forms.CheckBox serviceFilterCheckBox;
@@ -102,6 +103,7 @@ namespace MinimalFirewall
             this.advGroupingColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.advDescColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dateAddedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.autoAllowedColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.filterPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.programFilterCheckBox = new System.Windows.Forms.CheckBox();
             this.serviceFilterCheckBox = new System.Windows.Forms.CheckBox();
@@ -303,7 +305,8 @@ namespace MinimalFirewall
             this.advProfilesColumn,
             this.advGroupingColumn,
             this.advDescColumn,
-            this.dateAddedColumn});
+            this.dateAddedColumn,
+            this.autoAllowedColumn});
             this.rulesDataGridView.ContextMenuStrip = this.rulesContextMenu;
             this.rulesDataGridView.EnableHeadersVisualStyles = false;
             this.rulesDataGridView.GridColor = System.Drawing.SystemColors.Control;
@@ -449,6 +452,14 @@ namespace MinimalFirewall
             this.dateAddedColumn.Name = "dateAddedColumn";
             this.dateAddedColumn.ReadOnly = true;
             // 
+            // autoAllowedColumn
+            //
+            this.autoAllowedColumn.DataPropertyName = "AutoAllowedPublisher";
+            this.autoAllowedColumn.FillWeight = 8F;
+            this.autoAllowedColumn.HeaderText = "Origin";
+            this.autoAllowedColumn.Name = "autoAllowedColumn";
+            this.autoAllowedColumn.ReadOnly = true;
+            //
             // filterPanel
             // 
             this.filterPanel.Anchor = System.Windows.Forms.AnchorStyles.Left;

--- a/src/RulesControl.cs
+++ b/src/RulesControl.cs
@@ -156,6 +156,7 @@ namespace MinimalFirewall
                 _ when col == advGroupingColumn => rule.Grouping,
                 _ when col == advDescColumn => rule.Description,
                 _ when col == dateAddedColumn => rule.DateAdded.HasValue ? rule.DateAdded.Value.ToLocalTime() : null,
+                _ when col == autoAllowedColumn => string.IsNullOrEmpty(rule.AutoAllowedPublisher) ? "" : "Auto",
                 _ => e.Value
             };
         }
@@ -425,6 +426,10 @@ namespace MinimalFirewall
                     details.AppendLine($"Profiles: {rule.Profiles}");
                     details.AppendLine($"Group: {rule.Grouping}");
                     details.AppendLine($"Description: {rule.Description}");
+                    if (!string.IsNullOrEmpty(rule.AutoAllowedPublisher))
+                    {
+                        details.AppendLine($"Auto-allowed publisher: {rule.AutoAllowedPublisher}");
+                    }
                 }
 
                 if (details.Length > 0)


### PR DESCRIPTION
Adds a small Rules tab origin indicator for rules created by auto-allow.

Newly auto-allowed rules get an internal `MFW_AutoAllow_Publisher:[...]` description marker. `FirewallDataService` parses that marker back into rule metadata, strips it from the visible Description column, and the Rules tab shows `Auto` in a new `Origin` column.

Copy Details includes `Auto-allowed publisher: ...` when that metadata is present.

Only new auto-allowed rules are marked; existing rules are not backfilled.

---

Open to changing the approach if you'd prefer a different way to surface this. You can also just close this PR if you think this signal should stay out of the Rules tab for now.