### PR TITLE
fix: narrow WFP audit check to connection subcategory

### DIFF
--- a/src/FirewallActionService.cs
+++ b/src/FirewallActionService.cs
@@ -476,7 +476,7 @@ namespace MinimalFirewall
 
             ManageWslRules(newLockdownState);
 
-            if (newLockdownState && !AdminTaskService.IsAuditPolicyEnabled())
+            if (newLockdownState && !AdminTaskService.IsWfpConnectionAuditPolicyEnabled())
             {
                 SafeShowMessageBox(
                     "Failed to verify that Windows Security Auditing was enabled.\n\n" +

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -259,7 +259,7 @@ namespace MinimalFirewall
                 _eventListenerService.EnableAuditing();
                 _eventListenerService.Start();
 
-                if (!AdminTaskService.IsAuditPolicyEnabled())
+                if (!AdminTaskService.IsWfpConnectionAuditPolicyEnabled())
                 {
                     _activityLogger.LogDebug("[Startup] Lockdown is on but WFP audit policy is not enabled. Connection popups will not work until this is resolved.");
                     MessageBox.Show(this,

--- a/src/UtilityServices.cs
+++ b/src/UtilityServices.cs
@@ -60,6 +60,12 @@ namespace MinimalFirewall
             return IsAuditingEnabledForSubcategory(packetDropGuid) && IsAuditingEnabledForSubcategory(connectionGuid);
         }
 
+        public static bool IsWfpConnectionAuditPolicyEnabled()
+        {
+            var connectionGuid = new Guid("{0CCE9226-69AE-11D9-BED3-505054503030}");
+            return IsAuditingEnabledForSubcategory(connectionGuid);
+        }
+
         private const uint AUDIT_FAILURE = 0x00000002;
 
         [DllImport("advapi32.dll", SetLastError = true)]


### PR DESCRIPTION
Addresses #138.

`IsAuditPolicyEnabled()` checks both packet-drop and connection auditing, but the app only listens for Event ID 5157, which comes from the connection subcategory ({0CCE9226}).

This may cause a false warning when packet-drop auditing is disabled by group policy while connection auditing is enabled. Add `IsWfpConnectionAuditPolicyEnabled()` to check only the needed subcategory, and use it on startup and when toggling lockdown.