### PR TITLE
fix: FlatComboBox dark mode rendering

### DIFF
--- a/src/CreateAdvancedRuleForm.Designer.cs
+++ b/src/CreateAdvancedRuleForm.Designer.cs
@@ -365,9 +365,7 @@
             this.protocolGroupBox.Text = "Protocol";
             // 
             // protocolComboBox
-            // 
-            this.protocolComboBox.BorderColor = System.Drawing.Color.Gray;
-            this.protocolComboBox.ButtonColor = System.Drawing.Color.LightGray;
+            //
             this.protocolComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.protocolComboBox.FormattingEnabled = true;
             this.protocolComboBox.Location = new System.Drawing.Point(75, 22);
@@ -684,8 +682,6 @@
             // 
             this.groupComboBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupComboBox.BorderColor = System.Drawing.Color.Gray;
-            this.groupComboBox.ButtonColor = System.Drawing.Color.LightGray;
             this.groupComboBox.FormattingEnabled = true;
             this.groupComboBox.Location = new System.Drawing.Point(80, 13);
             this.groupComboBox.Name = "groupComboBox";

--- a/src/CreateProgramRuleForm.Designer.cs
+++ b/src/CreateProgramRuleForm.Designer.cs
@@ -90,8 +90,6 @@ namespace MinimalFirewall
             this.cancelButton.UseVisualStyleBackColor = true;
             this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
 
-            this.blockDirectionCombo.BorderColor = System.Drawing.Color.Gray;
-            this.blockDirectionCombo.ButtonColor = System.Drawing.Color.LightGray;
             this.blockDirectionCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.blockDirectionCombo.FormattingEnabled = true;
             this.blockDirectionCombo.Items.AddRange(new object[] {
@@ -103,8 +101,6 @@ namespace MinimalFirewall
             this.blockDirectionCombo.Size = new System.Drawing.Size(280, 23);
             this.blockDirectionCombo.TabIndex = 3;
 
-            this.allowDirectionCombo.BorderColor = System.Drawing.Color.Gray;
-            this.allowDirectionCombo.ButtonColor = System.Drawing.Color.LightGray;
             this.allowDirectionCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.allowDirectionCombo.FormattingEnabled = true;
             this.allowDirectionCombo.Items.AddRange(new object[] {

--- a/src/DarkModeCS.cs
+++ b/src/DarkModeCS.cs
@@ -365,6 +365,13 @@ namespace DarkModeForms
             }
             else if (control is ComboBox comboBox)
             {
+                if (control is FlatComboBox flatCombo)
+                {
+                    flatCombo.BorderColor = IsDarkMode ? OScolors.ControlDark : Color.Gray;
+                    flatCombo.ButtonColor = IsDarkMode ? OScolors.Surface : Color.LightGray;
+                    flatCombo.Invalidate();
+                }
+
                 if (comboBox.DropDownStyle != ComboBoxStyle.DropDownList)
                 {
                     comboBox.SelectionStart = comboBox.Text.Length;

--- a/src/FlatComboBox.cs
+++ b/src/FlatComboBox.cs
@@ -24,7 +24,7 @@ namespace DarkModeForms
             }
         }
 
-        private Color buttonColor = Color.LightGray;
+        private Color buttonColor = Color.FromArgb(55, 55, 55);
         [DefaultValue(typeof(Color), "LightGray")]
         public Color ButtonColor
         {
@@ -58,6 +58,18 @@ namespace DarkModeForms
                     if (dropDownButtonWidth < UIHelpers.Scale(12, g)) dropDownButtonWidth = UIHelpers.Scale(16, g);
 
                     var dropDownRect = new Rectangle(clientRect.Width - dropDownButtonWidth, 0, dropDownButtonWidth, clientRect.Height);
+                    var textPadding = UIHelpers.Scale(4, g);
+                    var textBackRect = new Rectangle(clientRect.Left, clientRect.Top, Math.Max(0, clientRect.Width - dropDownButtonWidth), clientRect.Height);
+                    var textRect = new Rectangle(clientRect.Left + textPadding, clientRect.Top, Math.Max(0, clientRect.Width - dropDownButtonWidth - (textPadding * 2)), clientRect.Height);
+
+                    #region Selected Text
+                    using (var b = new SolidBrush(BackColor))
+                    {
+                        g.FillRectangle(b, textBackRect);
+                    }
+
+                    TextRenderer.DrawText(g, Text, Font, textRect, ForeColor, TextFormatFlags.Left | TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine | TextFormatFlags.EndEllipsis);
+                    #endregion
 
                     #region DropDown Button
                     using (var b = new SolidBrush(Enabled ? ButtonColor : SystemColors.Control))
@@ -96,6 +108,12 @@ namespace DarkModeForms
             }
 
             base.WndProc(ref m);
+        }
+
+        protected override void OnBackColorChanged(EventArgs e)
+        {
+            base.OnBackColorChanged(e);
+            Invalidate();
         }
     }
 

--- a/src/WildcardCreatorForm.Designer.cs
+++ b/src/WildcardCreatorForm.Designer.cs
@@ -108,8 +108,6 @@ namespace MinimalFirewall
             // 
             // directionCombo
             // 
-            this.directionCombo.BorderColor = System.Drawing.Color.Gray;
-            this.directionCombo.ButtonColor = System.Drawing.Color.LightGray;
             this.directionCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.directionCombo.FormattingEnabled = true;
             this.directionCombo.Items.AddRange(new object[] {
@@ -275,8 +273,6 @@ namespace MinimalFirewall
             // 
             // protocolComboBox
             // 
-            this.protocolComboBox.BorderColor = System.Drawing.Color.Gray;
-            this.protocolComboBox.ButtonColor = System.Drawing.Color.LightGray;
             this.protocolComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.protocolComboBox.FormattingEnabled = true;
             this.protocolComboBox.Location = new System.Drawing.Point(124, 27);

--- a/src/WildcardCreatorForm.cs
+++ b/src/WildcardCreatorForm.cs
@@ -22,6 +22,9 @@ namespace MinimalFirewall
             dm.ColorMode = appSettings.Theme == "Dark" ? DarkModeCS.DisplayMode.DarkMode : DarkModeCS.DisplayMode.ClearMode;
             dm.ApplyTheme(appSettings.Theme == "Dark");
 
+            // Force repaint of FlatComboBox controls to ensure correct colors
+            directionCombo.Invalidate();
+            protocolComboBox.Invalidate();
 
             directionCombo.SelectedIndex = 0; // Default to first item
             protocolComboBox.Items.Clear();


### PR DESCRIPTION
FlatComboBox dropdowns had an issue in dark mode:
- Selected text wasn't visible (empty box)

Changes:
- Added text rendering to `FlatComboBox.WndProc` using `BackColor`/`ForeColor`
- Added `FlatComboBox` theme handling in `DarkModeCS` to set `BorderColor`/`ButtonColor`
- Removed designer-set `BorderColor`/`ButtonColor` from 4 designer files to prevent theme overrides
- Added `Invalidate()` calls in `WildcardCreatorForm` after theme application for correct initial colors
- Added `OnBackColorChanged` override to trigger repaint on color changes

The theme system now fully controls FlatComboBox colors, ensuring consistent dark mode appearance across all forms.