### PR TITLE
Fix security fail-open paths, functional bugs, and resource leaks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: Build (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      # The NetFwTypeLib COM reference needs the .NET Framework MSBuild
+      # (ResolveComReference is not supported by `dotnet build`).
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Restore
+        run: msbuild src/MinimalFirewall.sln /t:Restore /p:Configuration=Release /p:Platform=x64
+
+      - name: Build
+        run: msbuild src/MinimalFirewall.sln /t:Build /p:Configuration=Release /p:Platform=x64

--- a/src/AppSettings.cs
+++ b/src/AppSettings.cs
@@ -72,6 +72,11 @@ namespace MinimalFirewall
         public bool IsPopupsEnabled { get => _isPopupsEnabled; set => SetField(ref _isPopupsEnabled, value); }
         public bool IsLoggingEnabled { get => _isLoggingEnabled; set => SetField(ref _isLoggingEnabled, value); }
         public string Theme { get => _theme; set => SetField(ref _theme, value); }
+
+        // Single source of truth for the effective dark-mode state: an explicit
+        // "Dark"/"Light" setting wins; "Auto" follows the OS.
+        [JsonIgnore]
+        public bool IsEffectiveDarkTheme => _theme == "Dark" || (_theme == "Auto" && DarkModeForms.Theme.IsSystemDarkMode());
         public bool StartOnSystemStartup { get => _startOnSystemStartup; set => SetField(ref _startOnSystemStartup, value); }
         public bool CloseToTray { get => _closeToTray; set => SetField(ref _closeToTray, value); }
         public int AutoRefreshIntervalMinutes { get => _autoRefreshIntervalMinutes; set => SetField(ref _autoRefreshIntervalMinutes, value); }
@@ -178,7 +183,9 @@ namespace MinimalFirewall
                     ConfigPathManager.EnsureStorageDirectoryExists();
 
                     string json = JsonSerializer.Serialize(this, AppSettingsJsonContext.Default.AppSettings);
-                    File.WriteAllText(_configPath, json);
+                    string tempPath = _configPath + ".tmp";
+                    File.WriteAllText(tempPath, json);
+                    File.Move(tempPath, _configPath, overwrite: true);
                 }
                 catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
                 {

--- a/src/AuditControl.cs
+++ b/src/AuditControl.cs
@@ -572,12 +572,13 @@ namespace MinimalFirewall
         {
             diffRichTextBox.Clear();
 
-            bool isDark = Theme.IsSystemDarkMode();
-
             diffRichTextBox.BackColor = Theme.Colors.Surface;
             diffRichTextBox.ForeColor = Theme.Colors.TextActive;
-            Font boldFont = new(diffRichTextBox.Font ?? Control.DefaultFont, FontStyle.Bold);
+            // SelectionFont copies into the control, so these can be disposed
+            // when the method exits instead of leaking one set per selection.
             Font regFont = diffRichTextBox.Font ?? Control.DefaultFont;
+            using Font boldFont = new(regFont, FontStyle.Bold);
+            using Font strikeFont = new(regFont, FontStyle.Strikeout);
 
             Color oldColor = Theme.Colors.DangerText;
             Color newColor = Theme.Colors.SuccessText;
@@ -631,7 +632,7 @@ namespace MinimalFirewall
                 if (!string.Equals(oldVal, newVal, StringComparison.OrdinalIgnoreCase))
                 {
                     AppendText(diffRichTextBox, $"{label}: ", labelColor, boldFont);
-                    AppendText(diffRichTextBox, oldVal, oldColor, new Font(regFont, FontStyle.Strikeout));
+                    AppendText(diffRichTextBox, oldVal, oldColor, strikeFont);
                     AppendText(diffRichTextBox, " -> ", labelColor, regFont);
                     AppendText(diffRichTextBox, newVal, newColor, boldFont);
                     diffRichTextBox.AppendText(Environment.NewLine);

--- a/src/BackgroundFirewallTaskService.cs
+++ b/src/BackgroundFirewallTaskService.cs
@@ -331,8 +331,10 @@ namespace MinimalFirewall
                 p => _actionsService.RemoveWildcardDefinitionOnly(p.Wildcard), TaskResult.WildcardOnly),
                 [FirewallTaskType.DeleteAllMfwRules] = new ActionHandler<object>(
                 _ => _actionsService.DeleteAllMfwRules(), TaskResult.CacheOnly),
-                [FirewallTaskType.ImportRules] = new AsyncActionHandler<ImportRulesPayload>(
-                async p => await _actionsService.ImportRulesAsync(p.JsonContent, p.Replace), TaskResult.CacheOnly)
+                // Must not call ImportRulesAsync here: it awaits WhenIdleAsync, which can
+                // never complete while this handler itself counts as outstanding work.
+                [FirewallTaskType.ImportRules] = new ActionHandler<ImportRulesPayload>(
+                p => _actionsService.EnqueueImportTasks(p.JsonContent, p.Replace, out _, out _), TaskResult.CacheOnly)
             };
             return map;
         }

--- a/src/BrowseServicesForm.cs
+++ b/src/BrowseServicesForm.cs
@@ -16,7 +16,7 @@ namespace MinimalFirewall
             // prevents crashes if null list is passed
             _allServices = services ?? [];
 
-            bool isDark = appSettings.Theme == "Dark";
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;

--- a/src/CreateAdvancedRuleForm.cs
+++ b/src/CreateAdvancedRuleForm.cs
@@ -84,7 +84,7 @@ namespace MinimalFirewall
 
         private void ApplyDynamicTheme()
         {
-            bool isDark = _appSettings.Theme == "Dark";
+            bool isDark = _appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             BackColor = Theme.Colors.Background;

--- a/src/CreateProgramRuleForm.cs
+++ b/src/CreateProgramRuleForm.cs
@@ -8,11 +8,11 @@ namespace MinimalFirewall
         private readonly FirewallActionsService _actionsService;
 
 
-        public CreateProgramRuleForm(string[] filePaths, FirewallActionsService actionsService)
+        public CreateProgramRuleForm(string[] filePaths, FirewallActionsService actionsService, AppSettings appSettings)
         {
             InitializeComponent();
 
-            bool isDark = Theme.IsSystemDarkMode();
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;

--- a/src/DashboardControl.cs
+++ b/src/DashboardControl.cs
@@ -130,6 +130,10 @@ namespace MinimalFirewall
 
             detailsRichTextBox.Clear();
 
+            // SelectionFont copies the font into the control, so one shared
+            // instance per render is enough and can be disposed afterwards.
+            using var boldFont = new Font(detailsRichTextBox.Font, FontStyle.Bold);
+
             void AppendDetail(string label, string? value)
             {
                 if (string.IsNullOrEmpty(value))
@@ -142,7 +146,7 @@ namespace MinimalFirewall
 
                 // Centralized Theme Styling
                 detailsRichTextBox.SelectionColor = Theme.Colors.InfoText;
-                detailsRichTextBox.SelectionFont = new Font(detailsRichTextBox.Font, FontStyle.Bold);
+                detailsRichTextBox.SelectionFont = boldFont;
                 detailsRichTextBox.AppendText(label + ": ");
 
                 detailsRichTextBox.SelectionColor = Theme.Colors.TextActive;
@@ -252,9 +256,10 @@ namespace MinimalFirewall
                     bool isUwp = pending.AppPath.Contains("WindowsApps", StringComparison.OrdinalIgnoreCase) || (!pending.AppPath.Contains('\\') && !pending.AppPath.Contains(':'));
                     int iconIndex = isUwp ? _iconService.GetUwpIconIndex(pending.AppPath) : _iconService.GetIconIndex(pending.AppPath);
 
-                    if (iconIndex != -1 && _iconService.ImageList != null && iconIndex < _iconService.ImageList.Images.Count)
+                    var iconImage = _iconService.GetImage(iconIndex);
+                    if (iconImage != null)
                     {
-                        e.Value = _iconService.ImageList.Images[iconIndex];
+                        e.Value = iconImage;
                     }
                 }
             }

--- a/src/ExcludedFoldersForm.cs
+++ b/src/ExcludedFoldersForm.cs
@@ -12,7 +12,7 @@ namespace MinimalFirewall
 
             _appSettings = appSettings;
 
-            bool isDark = appSettings.Theme == "Dark" || (appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;

--- a/src/FirewallActionService.cs
+++ b/src/FirewallActionService.cs
@@ -271,19 +271,14 @@ namespace MinimalFirewall
                 return;
             }
 
-            var rulesToRemove = new List<string>();
+            // DeleteConflictingServiceRules deletes the matched rules itself.
             if (parsedDirection.HasFlag(Directions.Incoming))
             {
-                rulesToRemove.AddRange(FirewallRuleService.DeleteConflictingServiceRules(serviceName, (NET_FW_ACTION_)parsedAction, NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN));
+                FirewallRuleService.DeleteConflictingServiceRules(serviceName, (NET_FW_ACTION_)parsedAction, NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN);
             }
             if (parsedDirection.HasFlag(Directions.Outgoing))
             {
-                rulesToRemove.AddRange(FirewallRuleService.DeleteConflictingServiceRules(serviceName, (NET_FW_ACTION_)parsedAction, NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_OUT));
-            }
-
-            if (rulesToRemove.Count != 0)
-            {
-                FirewallRuleService.DeleteRulesByName(rulesToRemove);
+                FirewallRuleService.DeleteConflictingServiceRules(serviceName, (NET_FW_ACTION_)parsedAction, NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_OUT);
             }
 
             ProcessTcpAndUdpRules(parsedDirection, (dir, proto, suffix) =>
@@ -319,17 +314,14 @@ namespace MinimalFirewall
             }
 
             var packageFamilyNames = validApps.Select(app => app.PackageFamilyName).ToList();
-            var rulesToRemove = FirewallRuleService.DeleteUwpRules(packageFamilyNames);
+            // DeleteUwpRules already removes the old rules; new rules reuse the same
+            // names, so deleting the returned names afterwards would destroy them.
+            FirewallRuleService.DeleteUwpRules(packageFamilyNames);
             foreach (var app in validApps)
             {
                 void createRule(string name, Directions dir, Actions act) => CreateUwpRule(name, app.PackageFamilyName, dir, act, ProtocolTypes.Any.Value);
                 ApplyRuleAction(app.Name, action, createRule);
                 activityLogger.LogChange("UWP Rule Changed", action + " for " + app.Name);
-            }
-
-            if (rulesToRemove.Count != 0)
-            {
-                FirewallRuleService.DeleteRulesByName(rulesToRemove);
             }
         }
 
@@ -882,11 +874,19 @@ namespace MinimalFirewall
                 return;
             }
 
-            var ruleNames = changes.Select(c => c.Rule?.Name).Where(n => n != null).Select(n => n!).ToList();
-            if (ruleNames.Count != 0)
+            int accepted = 0;
+            foreach (var change in changes)
             {
-                activityLogger.LogChange("All Foreign Rules Accepted", $"{ruleNames.Count} rules accepted.");
-                activityLogger.LogDebug($"Sentry: Accepted all {ruleNames.Count} foreign rules.");
+                if (change?.Rule?.Name is not null)
+                {
+                    ProcessForeignRule(change, true, "Accepted");
+                    accepted++;
+                }
+            }
+
+            if (accepted != 0)
+            {
+                activityLogger.LogDebug($"Sentry: Accepted all {accepted} foreign rules.");
             }
         }
 
@@ -1482,10 +1482,30 @@ namespace MinimalFirewall
 
         public async Task ImportRulesAsync(string jsonContent, bool replace)
         {
+            if (!EnqueueImportTasks(jsonContent, replace, out int advancedCount, out int wildcardCount))
+            {
+                return;
+            }
+
+            // Wait for the queue to drain
+            await BackgroundTaskService!.WhenIdleAsync();
+
+            activityLogger.LogChange("Rules Imported", $"Imported {advancedCount} advanced rules and {wildcardCount} wildcard rules. Replace: {replace}");
+        }
+
+        // Enqueues the individual import tasks without waiting for them. The queue
+        // handler for ImportRules must use this instead of ImportRulesAsync: awaiting
+        // WhenIdleAsync from inside a handler deadlocks the single worker on its own
+        // queue (the handler counts as outstanding work until it returns).
+        public bool EnqueueImportTasks(string jsonContent, bool replace, out int advancedCount, out int wildcardCount)
+        {
+            advancedCount = 0;
+            wildcardCount = 0;
+
             if (BackgroundTaskService == null)
             {
                 activityLogger.LogDebug("[Import] BackgroundTaskService is not available.");
-                return;
+                return false;
             }
 
             try
@@ -1494,7 +1514,7 @@ namespace MinimalFirewall
                 if (container == null)
                 {
                     activityLogger.LogDebug("[Import] Failed to deserialize JSON content.");
-                    return;
+                    return false;
                 }
 
                 if (replace)
@@ -1508,22 +1528,22 @@ namespace MinimalFirewall
                     ruleVm.ApplicationName = PathResolver.ConvertFromEnvironmentPath(ruleVm.ApplicationName);
                     var payload = new CreateAdvancedRulePayload { ViewModel = ruleVm, InterfaceTypes = ruleVm.InterfaceTypes, IcmpTypesAndCodes = ruleVm.IcmpTypesAndCodes };
                     BackgroundTaskService.EnqueueTask(new FirewallTask(FirewallTaskType.CreateAdvancedRule, payload));
+                    advancedCount++;
                 }
 
                 foreach (var wildcardRule in container.WildcardRules ?? [])
                 {
                     wildcardRule.FolderPath = PathResolver.ConvertFromEnvironmentPath(wildcardRule.FolderPath);
                     BackgroundTaskService.EnqueueTask(new FirewallTask(FirewallTaskType.AddWildcardRule, wildcardRule));
+                    wildcardCount++;
                 }
 
-                // Wait for the queue to drain
-                await BackgroundTaskService.WhenIdleAsync();
-
-                activityLogger.LogChange("Rules Imported", $"Imported {container.AdvancedRules?.Count ?? 0} advanced rules and {container.WildcardRules?.Count ?? 0} wildcard rules. Replace: {replace}");
+                return true;
             }
             catch (JsonException ex)
             {
                 activityLogger.LogException("ImportRules", ex);
+                return false;
             }
         }
     }

--- a/src/FirewallDataService.cs
+++ b/src/FirewallDataService.cs
@@ -58,6 +58,64 @@ namespace MinimalFirewall
             return _uwpService.LoadUwpAppsFromCache();
         }
 
+        private int _uwpScanInProgress;
+
+        // UWP friendly-name resolution reads only the uwp_apps.json cache, so a
+        // forced refresh must actually run the scan that populates it. First run
+        // (empty cache) is awaited so names resolve immediately; afterwards the
+        // scan runs in the background because PowerShell/Get-AppxPackage takes
+        // seconds and this is called on every rules-tab rescan.
+        public async Task RefreshUwpAppsAsync(CancellationToken token)
+        {
+            if (Interlocked.CompareExchange(ref _uwpScanInProgress, 1, 0) == 1)
+            {
+                return;
+            }
+
+            bool releaseInline = true;
+            try
+            {
+                if (_uwpService.LoadUwpAppsFromCache().Count == 0)
+                {
+                    try
+                    {
+                        await _uwpService.GetUwpAppsAsync(token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+                else
+                {
+                    releaseInline = false;
+                    _ = RefreshUwpCacheInBackgroundAsync();
+                }
+            }
+            finally
+            {
+                if (releaseInline)
+                {
+                    Interlocked.Exchange(ref _uwpScanInProgress, 0);
+                }
+            }
+        }
+
+        private async Task RefreshUwpCacheInBackgroundAsync()
+        {
+            try
+            {
+                await _uwpService.GetUwpAppsAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[WARN] Background UWP cache refresh failed: {ex.Message}");
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _uwpScanInProgress, 0);
+            }
+        }
+
         private Task<List<AdvancedRuleViewModel>> FetchAllMfwRulesAsync(CancellationToken token)
         {
             return Task.Run(() =>
@@ -104,13 +162,24 @@ namespace MinimalFirewall
 
         public async Task<List<AdvancedRuleViewModel>> GetMfwRulesAsync(CancellationToken token)
         {
-            var result = await _localCache.GetOrCreateAsync(MfwRulesCacheKey, async entry =>
+            if (_localCache.TryGetValue(MfwRulesCacheKey, out List<AdvancedRuleViewModel>? cached) && cached != null)
             {
-                entry.SlidingExpiration = TimeSpan.FromMinutes(10);
-                return await FetchAllMfwRulesAsync(token);
-            });
+                return cached;
+            }
 
-            return result ?? [];
+            var result = await FetchAllMfwRulesAsync(token);
+
+            // A cancelled scan yields a partial/empty list. Caching it would make every
+            // consumer (rule-status checks, popup suppression) see zero MFW rules, and
+            // the sliding expiration keeps renewing the poisoned entry on each read.
+            if (!token.IsCancellationRequested)
+            {
+                var cacheOptions = new MemoryCacheEntryOptions()
+                    .SetSlidingExpiration(TimeSpan.FromMinutes(10));
+                _localCache.Set(MfwRulesCacheKey, result, cacheOptions);
+            }
+
+            return result;
         }
 
         public async Task<List<AggregatedRuleViewModel>> GetAggregatedRulesAsync(CancellationToken token, IProgress<int>? progress = null)

--- a/src/FirewallEventListenerService.cs
+++ b/src/FirewallEventListenerService.cs
@@ -127,17 +127,21 @@ namespace MinimalFirewall
 
             try
             {
-                string xmlContent = e.EventRecord.ToXml();
+                // The record wraps an unmanaged event-log handle and 5157 fires for
+                // nearly every blocked packet in lockdown mode — dispose it here;
+                // everything the async processing needs is extracted first.
+                using var record = e.EventRecord;
+                string xmlContent = record.ToXml();
 
                 // Culture-Invariant - Extract raw Direction integer from properties
                 int? rawDirectionCode = null;
-                if (e.EventRecord.Properties != null && e.EventRecord.Properties.Count > 2)
+                if (record.Properties != null && record.Properties.Count > 2)
                 {
                     try
                     {
-                        if (e.EventRecord.Properties[2].Value != null)
+                        if (record.Properties[2].Value != null)
                         {
-                            rawDirectionCode = Convert.ToInt32(e.EventRecord.Properties[2].Value);
+                            rawDirectionCode = Convert.ToInt32(record.Properties[2].Value);
                         }
                     }
                     catch { /* Ignore cast errors, fall back to XML parsing */ }

--- a/src/FirewallSentryService.cs
+++ b/src/FirewallSentryService.cs
@@ -95,7 +95,14 @@ namespace MinimalFirewall
 
                 using var targetInstance = (ManagementBaseObject)newEvent["TargetInstance"];
 
-                string ruleName = targetInstance["InstanceID"]?.ToString() ?? string.Empty;
+                // InstanceID is an internal identifier (typically a GUID) that does not
+                // match the display name INetFwRules.Item() resolves — rules added via
+                // wf.msc or PowerShell would silently fail the later COM lookup.
+                string ruleName = targetInstance["DisplayName"]?.ToString() ?? string.Empty;
+                if (string.IsNullOrEmpty(ruleName))
+                {
+                    ruleName = targetInstance["InstanceID"]?.ToString() ?? string.Empty;
+                }
                 string grouping = targetInstance["DisplayGroup"]?.ToString() ?? string.Empty;
 
                 if (string.IsNullOrEmpty(ruleName) || IsMfwRule(grouping))

--- a/src/IconService.cs
+++ b/src/IconService.cs
@@ -211,8 +211,36 @@ namespace MinimalFirewall
             return _systemIconIndex;
         }
 
+        private readonly Dictionary<int, Image> _imageInstanceCache = [];
+
+        // ImageList.Images[i] allocates a new Bitmap copy on every access; grids
+        // ask for icons from CellFormatting/CellValueNeeded on each repaint, so
+        // hand out one cached copy per index instead of a fresh copy per paint.
+        public Image? GetImage(int index)
+        {
+            if (_imageList == null || index < 0 || index >= _imageList.Images.Count)
+            {
+                return null;
+            }
+
+            if (_imageInstanceCache.TryGetValue(index, out var cached))
+            {
+                return cached;
+            }
+
+            var image = _imageList.Images[index];
+            _imageInstanceCache[index] = image;
+            return image;
+        }
+
         public void ClearCache()
         {
+            foreach (var image in _imageInstanceCache.Values)
+            {
+                image.Dispose();
+            }
+            _imageInstanceCache.Clear();
+
             if (_imageList == null)
             {
                 _iconCache.Clear();

--- a/src/LiveConnectionsControl.cs
+++ b/src/LiveConnectionsControl.cs
@@ -197,9 +197,10 @@ namespace MinimalFirewall
                         bool isUwp = conn.ProcessPath.Contains("WindowsApps", StringComparison.OrdinalIgnoreCase) || (!conn.ProcessPath.Contains('\\') && !conn.ProcessPath.Contains(':'));
                         int iconIndex = isUwp ? _iconService.GetUwpIconIndex(conn.ProcessPath) : _iconService.GetIconIndex(conn.ProcessPath);
 
-                        if (iconIndex != -1 && _iconService.ImageList != null)
+                        var iconImage = _iconService.GetImage(iconIndex);
+                        if (iconImage != null)
                         {
-                            e.Value = _iconService.ImageList.Images[iconIndex];
+                            e.Value = iconImage;
                         }
                     }
                     break;

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -1311,49 +1311,68 @@ namespace MinimalFirewall
                 return;
             }
 
-            BeginInvoke(new Action(() =>
+            // Threadpool timer callback: the form can be disposed between the
+            // timer firing and this call (e.g. app exit), so guard like the
+            // auto-refresh timer does.
+            if (IsDisposed || !IsHandleCreated)
             {
-                if (mainTabControl.SelectedTab != null && mainTabControl.SelectedTab.Name == tabName)
-                {
-                    return;
-                }
+                return;
+            }
 
-                switch (tabName)
+            try
+            {
+                BeginInvoke(new Action(() =>
                 {
-                    case "rulesTabPage":
-                        _mainViewModel.ClearRulesData();
-                        break;
-                    case "wildcardRulesTabPage":
-                        wildcardRulesControl1.ClearRules();
-                        break;
-                    case "systemChangesTabPage":
-                        if (_auditStatusForm?.IsDisposed == false)
-                        {
-                            _auditStatusForm?.Close();
-                        }
+                    if (IsDisposed)
+                    {
+                        return;
+                    }
+                    if (mainTabControl.SelectedTab != null && mainTabControl.SelectedTab.Name == tabName)
+                    {
+                        return;
+                    }
 
-                        _auditStatusForm = null;
-                        _mainViewModel.SystemChanges.Clear();
-                        auditControl1.ApplySearchFilter();
-                        UpdateUiWithChangesCount();
-                        _firewallSentryService.Stop();
-                        _isSentryServiceStarted = false;
-                        break;
-                    case "groupsTabPage":
-                        groupsControl1.ClearGroups();
-                        break;
-                    case "liveConnectionsTabPage":
-                        liveConnectionsControl1.OnTabDeselected();
-                        break;
-                }
+                    switch (tabName)
+                    {
+                        case "rulesTabPage":
+                            _mainViewModel.ClearRulesData();
+                            break;
+                        case "wildcardRulesTabPage":
+                            wildcardRulesControl1.ClearRules();
+                            break;
+                        case "systemChangesTabPage":
+                            if (_auditStatusForm?.IsDisposed == false)
+                            {
+                                _auditStatusForm?.Close();
+                            }
 
-                GC.Collect();
-                if (_tabUnloadTimers.TryGetValue(tabName, out var timer))
-                {
-                    timer.Dispose();
-                    _tabUnloadTimers.Remove(tabName);
-                }
-            }));
+                            _auditStatusForm = null;
+                            _mainViewModel.SystemChanges.Clear();
+                            auditControl1.ApplySearchFilter();
+                            UpdateUiWithChangesCount();
+                            _firewallSentryService.Stop();
+                            _isSentryServiceStarted = false;
+                            break;
+                        case "groupsTabPage":
+                            groupsControl1.ClearGroups();
+                            break;
+                        case "liveConnectionsTabPage":
+                            liveConnectionsControl1.OnTabDeselected();
+                            break;
+                    }
+
+                    GC.Collect();
+                    if (_tabUnloadTimers.TryGetValue(tabName, out var timer))
+                    {
+                        timer.Dispose();
+                        _tabUnloadTimers.Remove(tabName);
+                    }
+                }));
+            }
+            catch (Exception ex) when (ex is ObjectDisposedException or InvalidOperationException)
+            {
+                // Form was torn down between the guard and the BeginInvoke.
+            }
         }
 
 
@@ -1525,7 +1544,7 @@ namespace MinimalFirewall
             return _scanCts.Token;
         }
 
-        private bool IsDarkModeEnabled => _appSettings.Theme == "Auto" ? Theme.IsSystemDarkMode() : _appSettings.Theme == "Dark";
+        private bool IsDarkModeEnabled => _appSettings.IsEffectiveDarkTheme;
 
         private void SafeInvoke(Action action)
         {

--- a/src/MainViewModel.cs
+++ b/src/MainViewModel.cs
@@ -111,6 +111,11 @@ namespace MinimalFirewall
             AllAggregatedRules = await _dataService.GetAggregatedRulesAsync(token, progress);
         }
 
+        public async Task RefreshUwpAppsAsync(CancellationToken token)
+        {
+            await _dataService.RefreshUwpAppsAsync(token);
+        }
+
         public async Task RefreshLiveConnectionsAsync(CancellationToken token, IProgress<int>? progress = null)
         {
             var vms = await Task.Run(() =>
@@ -272,6 +277,7 @@ namespace MinimalFirewall
                         var domains = domainsRaw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
                         var newIps = new List<string>();
+                        bool anyResolveFailed = false;
                         foreach (var domain in domains)
                         {
                             try
@@ -281,17 +287,29 @@ namespace MinimalFirewall
                             }
                             catch (Exception ex)
                             {
+                                anyResolveFailed = true;
                                 Debug.WriteLine($"[WARN] DNS Refresh: Failed to resolve '{domain}'. Keeping old IPs. {ex.Message}");
                             }
                         }
 
                         if (newIps.Count > 0)
                         {
-                            string newRemoteAddresses = string.Join(",", newIps.Distinct());
+                            var updatedIps = new HashSet<string>(newIps.Select(NormalizeIpEntry), StringComparer.OrdinalIgnoreCase);
+                            var currentIps = SplitIpList(rule.RemoteAddresses);
 
-                            // Check if IPs have actually shifted
-                            if (!string.Equals(rule.RemoteAddresses, newRemoteAddresses, StringComparison.OrdinalIgnoreCase))
+                            // A domain that failed to resolve must keep its previously known
+                            // IPs in the rule; dropping them would silently un-block it.
+                            // Old IPs are only pruned when every domain resolves successfully.
+                            if (anyResolveFailed)
                             {
+                                updatedIps.UnionWith(currentIps);
+                            }
+
+                            // Compare as normalized sets: Windows stores single hosts with a
+                            // /255.255.255.255 mask and DNS answer order varies per query.
+                            if (!updatedIps.SetEquals(currentIps))
+                            {
+                                string newRemoteAddresses = string.Join(",", updatedIps);
                                 _activityLogger.LogDebug($"DNS Refresh: IPs changed for '{rule.Name}'. Updating Windows Firewall.");
                                 FirewallRuleService.UpdateRuleRemoteAddresses(rule.Name, newRemoteAddresses);
                                 rule.RemoteAddresses = newRemoteAddresses; // Update local cache
@@ -320,6 +338,38 @@ namespace MinimalFirewall
             }
         }
 
+        private static HashSet<string> SplitIpList(string? addresses)
+        {
+            var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrWhiteSpace(addresses) || addresses == "*")
+            {
+                return set;
+            }
+
+            foreach (var entry in addresses.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                set.Add(NormalizeIpEntry(entry));
+            }
+            return set;
+        }
+
+        private static string NormalizeIpEntry(string entry)
+        {
+            // Windows Firewall stores single hosts as "x.x.x.x/255.255.255.255"
+            // (or "/32", "/128"); strip the single-host mask so comparisons
+            // don't see phantom changes.
+            int slash = entry.IndexOf('/');
+            if (slash > 0)
+            {
+                string mask = entry[(slash + 1)..];
+                if (mask is "255.255.255.255" or "32" or "128")
+                {
+                    return entry[..slash];
+                }
+            }
+            return entry;
+        }
+
         public void UpdateDnsTimerInterval()
         {
             if (_dnsRefreshTimer == null) return;
@@ -327,8 +377,16 @@ namespace MinimalFirewall
             _dnsRefreshTimer.Change(TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(dnsInterval));
         }
 
+        private string _lastFilterSearchText = string.Empty;
+        private HashSet<RuleType> _lastFilterEnabledTypes = [];
+        private bool _lastFilterShowSystemRules;
+
         public void ApplyRulesFilters(string searchText, HashSet<RuleType> enabledTypes, bool showSystemRules)
         {
+            _lastFilterSearchText = searchText;
+            _lastFilterEnabledTypes = enabledTypes;
+            _lastFilterShowSystemRules = showSystemRules;
+
             IEnumerable<AggregatedRuleViewModel> filteredRules = AllAggregatedRules;
 
             if (!showSystemRules)
@@ -357,7 +415,9 @@ namespace MinimalFirewall
         {
             newRule.DateAdded ??= DateTime.UtcNow;
             AllAggregatedRules.Add(newRule);
-            ApplyRulesFilters(string.Empty, [], false);
+            // Re-apply the filters the Rules tab last used — creating a rule from a
+            // popup must not silently wipe the user's search text and checkboxes.
+            ApplyRulesFilters(_lastFilterSearchText, _lastFilterEnabledTypes, _lastFilterShowSystemRules);
         }
 
         private static Func<AggregatedRuleViewModel, object> GetRuleKeySelector(int columnIndex)
@@ -845,16 +905,32 @@ namespace MinimalFirewall
             catch (ObjectDisposedException) { } // timer disposed during shutdown
         }
 
-        private async void DebouncedSentryRefresh(object? state)
+        private void DebouncedSentryRefresh(object? state)
         {
-            try
+            async void runScan()
             {
-                _activityLogger.LogDebug("Sentry: Debounce timer elapsed. Checking for foreign rules.");
-                await ScanForSystemChangesAsync(CancellationToken.None);
+                try
+                {
+                    _activityLogger.LogDebug("Sentry: Debounce timer elapsed. Checking for foreign rules.");
+                    await ScanForSystemChangesAsync(CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _activityLogger.LogException("Error during sentry refresh", ex);
+                }
             }
-            catch (Exception ex)
+
+            // SystemChanges and the snapshot file are only ever touched from the UI
+            // thread. This runs on a threadpool timer, so start the scan on the UI
+            // context — the post-await continuation then stays there instead of
+            // mutating the shared list concurrently with UI readers.
+            if (_uiContext != null)
             {
-                _activityLogger.LogException("Error during sentry refresh", ex);
+                _uiContext.Post(_ => runScan(), null);
+            }
+            else
+            {
+                runScan();
             }
         }
 

--- a/src/ManagePublishersForm.cs
+++ b/src/ManagePublishersForm.cs
@@ -13,7 +13,7 @@ namespace MinimalFirewall
         {
             InitializeComponent();
 
-            bool isDark = appSettings.Theme == "Dark" || (appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             BackColor = Theme.Colors.Background;

--- a/src/RuleWizardForm.cs
+++ b/src/RuleWizardForm.cs
@@ -44,7 +44,7 @@ namespace MinimalFirewall
         public RuleWizardForm(FirewallActionsService actionsService, WildcardRuleService wildcardRuleService, BackgroundFirewallTaskService backgroundTaskService, AppSettings appSettings)
         {
             InitializeComponent();
-            bool isDark = appSettings.Theme == "Dark" || (appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;

--- a/src/RulesControl.cs
+++ b/src/RulesControl.cs
@@ -111,6 +111,10 @@ namespace MinimalFirewall
         #region Data & Logic
         public async Task RefreshDataAsync(bool forceUwpScan = false, IProgress<int>? progress = null, CancellationToken token = default)
         {
+            if (forceUwpScan)
+            {
+                await _mainViewModel.RefreshUwpAppsAsync(token);
+            }
             await _mainViewModel.RefreshRulesDataAsync(token, progress);
             await DisplayRulesAsync();
         }
@@ -565,9 +569,7 @@ namespace MinimalFirewall
                 ? _iconService.GetUwpIconIndex(rule.ApplicationName)
                 : _iconService.GetIconIndex(rule.ApplicationName);
 
-            return (iconIndex != -1 && _iconService.ImageList != null)
-                   ? _iconService.ImageList.Images[iconIndex]
-                   : null;
+            return _iconService.GetImage(iconIndex);
         }
 
         private static string GetDomainsFromDescription(string? description)

--- a/src/SettingsControl.cs
+++ b/src/SettingsControl.cs
@@ -114,7 +114,7 @@ namespace MinimalFirewall
             closeToTraySwitch.Checked = _appSettings.CloseToTray;
             startOnStartupSwitch.Checked = _appSettings.StartOnSystemStartup;
             autoThemeSwitch.Checked = _appSettings.Theme == "Auto";
-            darkModeSwitch.Checked = _appSettings.Theme == "Dark" || (_appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            darkModeSwitch.Checked = _appSettings.IsEffectiveDarkTheme;
             darkModeSwitch.Enabled = !autoThemeSwitch.Checked;
             popupsSwitch.Checked = _appSettings.IsPopupsEnabled;
             loggingSwitch.Checked = _appSettings.IsLoggingEnabled;
@@ -487,6 +487,41 @@ namespace MinimalFirewall
                 try
                 {
                     string jsonContent = await File.ReadAllTextAsync(openDialog.FileName);
+
+                    // The file is untrusted input: summarize what it will do before
+                    // touching the firewall, so a doctored "backup" can't silently
+                    // open network access.
+                    ExportContainer? container;
+                    try
+                    {
+                        container = System.Text.Json.JsonSerializer.Deserialize(jsonContent, ExportContainerJsonContext.Default.ExportContainer);
+                    }
+                    catch (System.Text.Json.JsonException)
+                    {
+                        container = null;
+                    }
+
+                    if (container == null)
+                    {
+                        Messenger.MessageBox("The selected file is not a valid Minimal Firewall rules backup.", "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        return;
+                    }
+
+                    int advancedCount = container.AdvancedRules?.Count ?? 0;
+                    int allowCount = container.AdvancedRules?.Count(r => r != null && string.Equals(r.Status, "Allow", StringComparison.OrdinalIgnoreCase)) ?? 0;
+                    int wildcardCount = container.WildcardRules?.Count ?? 0;
+
+                    string summary =
+                        $"This file contains {advancedCount} rule(s) ({allowCount} Allow) and {wildcardCount} wildcard rule(s)." +
+                        (replace ? "\nAll existing Minimal Firewall rules will be deleted first." : string.Empty) +
+                        "\n\nOnly import files you created yourself or fully trust — imported Allow rules open network access for the programs they list.\n\nContinue?";
+
+                    var proceed = Messenger.MessageBox(summary, "Confirm Import", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                    if (proceed != DialogResult.Yes)
+                    {
+                        return;
+                    }
+
                     await _actionsService.ImportRulesAsync(jsonContent, replace);
                     await (DataRefreshRequested?.Invoke() ?? Task.CompletedTask);
 

--- a/src/SignatureValidationService.cs
+++ b/src/SignatureValidationService.cs
@@ -41,9 +41,10 @@ namespace MinimalFirewall
         }
 
         private const int WTD_UI_NONE = 2;
-        private const int WTD_REVOKE_NONE = 0;
+        private const int WTD_REVOKE_WHOLECHAIN = 1;
         private const int WTD_CHOICE_FILE = 1;
         private const int WTD_STATEACTION_IGNORE = 0;
+        private const int WTD_REVOCATION_CHECK_CHAIN = 0x40;
 
         public static bool GetPublisherInfo(string filePath, out string? publisherName)
             => IsSignatureTrusted(filePath, out publisherName);
@@ -140,13 +141,16 @@ namespace MinimalFirewall
                     pPolicyCallbackData = IntPtr.Zero,
                     pSIPClientData = IntPtr.Zero,
                     dwUIChoice = WTD_UI_NONE,
-                    fdwRevocationChecks = WTD_REVOKE_NONE,
+                    // Revoked code-signing certs (the standard response to cert theft) must not
+                    // pass the auto-allow gate. If revocation status can't be determined
+                    // (e.g. offline), the check fails and the user gets a prompt instead.
+                    fdwRevocationChecks = WTD_REVOKE_WHOLECHAIN,
                     dwUnionChoice = WTD_CHOICE_FILE,
                     pUnion = pFileInfo,
                     dwStateAction = WTD_STATEACTION_IGNORE,
                     hWVTStateData = IntPtr.Zero,
                     pwszURLReference = IntPtr.Zero,
-                    dwProvFlags = 0,
+                    dwProvFlags = WTD_REVOCATION_CHECK_CHAIN,
                     dwUIContext = 0,
                     pSignatureSettings = IntPtr.Zero
                 };

--- a/src/TemporaryRuleManager.cs
+++ b/src/TemporaryRuleManager.cs
@@ -54,7 +54,11 @@ namespace MinimalFirewall
 
                     var rulesToSave = new Dictionary<string, DateTime>(_temporaryRules, StringComparer.OrdinalIgnoreCase);
                     string json = JsonSerializer.Serialize(rulesToSave, TempRuleJsonContext.Default.DictionaryStringDateTime);
-                    File.WriteAllText(_storagePath, json);
+                    // A torn write here would make the app forget which rules are temporary,
+                    // leaving expired Allow rules in the firewall forever.
+                    string tempPath = _storagePath + ".tmp";
+                    File.WriteAllText(tempPath, json);
+                    File.Move(tempPath, _storagePath, overwrite: true);
                 }
                 catch (Exception ex)
                 {

--- a/src/TrustedCertificatesForm.cs
+++ b/src/TrustedCertificatesForm.cs
@@ -13,7 +13,7 @@ namespace MinimalFirewall
         {
             InitializeComponent();
 
-            bool isDark = appSettings.Theme == "Dark" || (appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;

--- a/src/Utilities.cs
+++ b/src/Utilities.cs
@@ -180,25 +180,27 @@ namespace MinimalFirewall
                 Debug.WriteLine($"[WARN] PathResolver failed to build DOS device map: {ex.Message}");
             }
 
-            var specialFolders = new[]
+            // Tokens must be REAL Windows environment variables: import expands them
+            // via Environment.ExpandEnvironmentVariables, so enum member names like
+            // %LocalApplicationData% would survive as literals and break the rule.
+            var specialFolders = new (Environment.SpecialFolder Folder, string EnvVar)[]
             {
-                Environment.SpecialFolder.UserProfile,
-                Environment.SpecialFolder.ApplicationData,
-                Environment.SpecialFolder.LocalApplicationData,
-                Environment.SpecialFolder.CommonApplicationData,
-                Environment.SpecialFolder.System,
-                Environment.SpecialFolder.ProgramFiles,
-                Environment.SpecialFolder.ProgramFilesX86,
-                Environment.SpecialFolder.Windows
+                (Environment.SpecialFolder.UserProfile, "%USERPROFILE%"),
+                (Environment.SpecialFolder.ApplicationData, "%APPDATA%"),
+                (Environment.SpecialFolder.LocalApplicationData, "%LOCALAPPDATA%"),
+                (Environment.SpecialFolder.CommonApplicationData, "%ProgramData%"),
+                (Environment.SpecialFolder.System, @"%SystemRoot%\System32"),
+                (Environment.SpecialFolder.ProgramFiles, "%ProgramFiles%"),
+                (Environment.SpecialFolder.ProgramFilesX86, "%ProgramFiles(x86)%"),
+                (Environment.SpecialFolder.Windows, "%SystemRoot%")
             };
-            foreach (var folder in specialFolders)
+            foreach (var (folder, envVar) in specialFolders)
             {
                 try
                 {
                     string path = Environment.GetFolderPath(folder, Environment.SpecialFolderOption.DoNotVerify);
                     if (!string.IsNullOrEmpty(path))
                     {
-                        string envVar = $"%{folder}%";
                         _envVarMap[path] = envVar;
                     }
                 }
@@ -236,13 +238,31 @@ namespace MinimalFirewall
 
             try
             {
-                return Environment.ExpandEnvironmentVariables(environmentPath);
+                return Environment.ExpandEnvironmentVariables(TranslateLegacyTokens(environmentPath));
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"[WARN] ConvertFromEnvironmentPath failed: {ex.Message}");
                 return environmentPath;
             }
+        }
+
+        // Older exports used Environment.SpecialFolder member names, most of which
+        // are not real environment variables; translate them so old backups import.
+        private static string TranslateLegacyTokens(string path)
+        {
+            if (!path.Contains('%'))
+            {
+                return path;
+            }
+
+            return path
+                .Replace("%LocalApplicationData%", "%LOCALAPPDATA%", StringComparison.OrdinalIgnoreCase)
+                .Replace("%ApplicationData%", "%APPDATA%", StringComparison.OrdinalIgnoreCase)
+                .Replace("%CommonApplicationData%", "%ProgramData%", StringComparison.OrdinalIgnoreCase)
+                .Replace("%System%", @"%SystemRoot%\System32", StringComparison.OrdinalIgnoreCase)
+                .Replace("%ProgramFilesX86%", "%ProgramFiles(x86)%", StringComparison.OrdinalIgnoreCase)
+                .Replace("%Windows%", "%SystemRoot%", StringComparison.OrdinalIgnoreCase);
         }
 
         public static string NormalizePath(string path)

--- a/src/WildCardRuleService.cs
+++ b/src/WildCardRuleService.cs
@@ -168,7 +168,9 @@ namespace MinimalFirewall
             try
             {
                 string json = JsonSerializer.Serialize(_rules, WildcardRuleJsonContext.Default.ListWildcardRule);
-                File.WriteAllText(_configPath, json);
+                string tempPath = _configPath + ".tmp";
+                File.WriteAllText(tempPath, json);
+                File.Move(tempPath, _configPath, overwrite: true);
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {

--- a/src/WildcardCreatorForm.cs
+++ b/src/WildcardCreatorForm.cs
@@ -19,7 +19,7 @@ namespace MinimalFirewall
             InitializeComponent();
 
             // Apply Theme
-            bool isDark = appSettings.Theme == "Dark" || (appSettings.Theme == "Auto" && Theme.IsSystemDarkMode());
+            bool isDark = appSettings.IsEffectiveDarkTheme;
             Theme.Colors = Theme.GetSystemColors(isDark ? 0 : 1);
             Theme.ApplyTitleBarTheme(this.Handle, isDark ? Theme.DisplayMode.DarkMode : Theme.DisplayMode.ClearMode);
             this.BackColor = Theme.Colors.Background;


### PR DESCRIPTION
Security (fail-open):
- DNS refresh: keep previously blocked IPs when a domain fails to resolve; only prune old IPs when every domain in the rule resolves. Compare address sets normalized (single-host masks, order) so rules are no longer rewritten on every cycle.
- Enable certificate revocation checking (WTD_REVOKE_WHOLECHAIN + WTD_REVOCATION_CHECK_CHAIN) so revoked signing certs cannot pass the auto-allow gate.
- Write settings, wildcard rules, and temporary rules atomically (tmp + rename) like the other state files, so a crash mid-write no longer wipes settings or turns temporary Allow rules permanent.
- Rule import now shows a summary confirmation (rule counts, Allow count, replace warning) before touching the firewall.

Functional fixes:
- ApplyUwpRuleChange deleted the rules it had just created (old and new rules share names); drop the redundant post-create delete. Same cleanup in ApplyServiceRuleChange.
- Sentry now reads the WMI DisplayName (InstanceID is a GUID that never matches the COM display-name lookup), so rules added via wf.msc or PowerShell are detected instead of silently dropped.
- Wire forceUwpScan to an actual UWP scan: first run is awaited to populate the empty cache, later runs refresh it in the background.
- ImportRules queue handler no longer awaits its own queue (deadlock); the handler enqueues sub-tasks via EnqueueImportTasks instead.
- Don't cache the MFW rule list produced by a cancelled scan; the empty list poisoned popup suppression for as long as reads renewed it.
- Sentry scans now start on the UI context so SystemChanges is never mutated concurrently with UI readers.
- Guard the tab-unload timer's BeginInvoke against a disposed form (crash on exit).
- AcceptAllForeignRules actually enables the rules instead of only logging success.
- Export writes real environment variables (%LOCALAPPDATA% etc.) and import translates the old enum-name tokens so existing backups and cross-machine imports resolve.
- Creating a rule re-applies the Rules tab's current filters instead of resetting search/checkbox state.
- Unify dark-mode detection behind AppSettings.IsEffectiveDarkTheme; the advanced-rule, program-rule, and browse-services dialogs now honor both the explicit setting and Auto mode.

Resource handling:
- Dispose EventRecord in the 5157 handler (one unmanaged handle per blocked packet in lockdown mode).
- Cache per-index ImageList copies in IconService and reuse fonts in detail/diff rendering instead of allocating GDI objects per paint.

CI:
- Add a windows-latest build workflow (MSBuild, needed for the NetFwTypeLib COM reference).


Claude-Session: https://claude.ai/code/session_01U4iitMztCwX1h85kjAnLWw