### PR TITLE
fix: Origin column width

### DIFF
--- a/src/RulesControl.Designer.cs
+++ b/src/RulesControl.Designer.cs
@@ -496,6 +496,7 @@ namespace MinimalFirewall
             // 
             // autoAllowedColumn
             // 
+            autoAllowedColumn.AutoSizeMode = DataGridViewAutoSizeColumnMode.ColumnHeader;
             autoAllowedColumn.DataPropertyName = "AutoAllowedPublisher";
             autoAllowedColumn.FillWeight = 8F;
             autoAllowedColumn.HeaderText = "Origin";


### PR DESCRIPTION
The Origin column was taking up more space than it needed. It now sizes itself to the header so it stays compact.

I just noticed Inbound, Outbound, and Protocol might benefit from the same treatment. I left them unchanged for now, but I can update them too if you think it makes sense.